### PR TITLE
PDFCLOUD-2953 | Add types for the Documentation overhaul

### DIFF
--- a/src/api/documentation-section/content-types/documentation-section/schema.json
+++ b/src/api/documentation-section/content-types/documentation-section/schema.json
@@ -1,0 +1,39 @@
+{
+  "kind": "collectionType",
+  "collectionName": "documentation_sections",
+  "info": {
+    "singularName": "documentation-section",
+    "pluralName": "documentation-sections",
+    "displayName": "Documentation Section",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "content": {
+      "type": "richtext",
+      "required": true
+    },
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text"
+    },
+    "creation_date": {
+      "type": "date"
+    },
+    "documentation_subsections": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::documentation-section.documentation-section"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
+    }
+  }
+}

--- a/src/api/documentation-section/controllers/documentation-section.js
+++ b/src/api/documentation-section/controllers/documentation-section.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation-section controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::documentation-section.documentation-section');

--- a/src/api/documentation-section/routes/documentation-section.js
+++ b/src/api/documentation-section/routes/documentation-section.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation-section router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::documentation-section.documentation-section');

--- a/src/api/documentation-section/services/documentation-section.js
+++ b/src/api/documentation-section/services/documentation-section.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation-section service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::documentation-section.documentation-section');

--- a/src/api/documentation-topic/content-types/documentation-topic/schema.json
+++ b/src/api/documentation-topic/content-types/documentation-topic/schema.json
@@ -1,0 +1,41 @@
+{
+  "kind": "collectionType",
+  "collectionName": "documentation_topics",
+  "info": {
+    "singularName": "documentation-topic",
+    "pluralName": "documentation-topics",
+    "displayName": "Documentation Topic",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "content": {
+      "type": "richtext",
+      "required": false
+    },
+    "creation_date": {
+      "type": "date"
+    },
+    "title": {
+      "type": "string",
+      "required": true,
+      "unique": false
+    },
+    "description": {
+      "type": "text"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "documentation_sections": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::documentation-section.documentation-section"
+    }
+  }
+}

--- a/src/api/documentation-topic/controllers/documentation-topic.js
+++ b/src/api/documentation-topic/controllers/documentation-topic.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation-topic controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::documentation-topic.documentation-topic');

--- a/src/api/documentation-topic/routes/documentation-topic.js
+++ b/src/api/documentation-topic/routes/documentation-topic.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation-topic router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::documentation-topic.documentation-topic');

--- a/src/api/documentation-topic/services/documentation-topic.js
+++ b/src/api/documentation-topic/services/documentation-topic.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation-topic service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::documentation-topic.documentation-topic');

--- a/src/api/documentation/content-types/documentation/schema.json
+++ b/src/api/documentation/content-types/documentation/schema.json
@@ -1,0 +1,26 @@
+{
+  "kind": "singleType",
+  "collectionName": "documentations",
+  "info": {
+    "singularName": "documentation",
+    "pluralName": "documentations",
+    "displayName": "Documentation"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "text"
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.seo"
+    }
+  }
+}

--- a/src/api/documentation/controllers/documentation.js
+++ b/src/api/documentation/controllers/documentation.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::documentation.documentation');

--- a/src/api/documentation/routes/documentation.js
+++ b/src/api/documentation/routes/documentation.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::documentation.documentation');

--- a/src/api/documentation/services/documentation.js
+++ b/src/api/documentation/services/documentation.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::documentation.documentation');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1021,6 +1021,129 @@ export interface ApiChatFeedbackModalChatFeedbackModal
   };
 }
 
+export interface ApiDocumentationDocumentation extends Schema.SingleType {
+  collectionName: 'documentations';
+  info: {
+    singularName: 'documentation';
+    pluralName: 'documentations';
+    displayName: 'Documentation';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    seo: Attribute.Component<'shared.seo'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::documentation.documentation',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::documentation.documentation',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiDocumentationSectionDocumentationSection
+  extends Schema.CollectionType {
+  collectionName: 'documentation_sections';
+  info: {
+    singularName: 'documentation-section';
+    pluralName: 'documentation-sections';
+    displayName: 'Documentation Section';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    content: Attribute.RichText & Attribute.Required;
+    title: Attribute.String & Attribute.Required;
+    description: Attribute.Text;
+    creation_date: Attribute.Date;
+    documentation_subsections: Attribute.Relation<
+      'api::documentation-section.documentation-section',
+      'oneToMany',
+      'api::documentation-section.documentation-section'
+    >;
+    slug: Attribute.UID<
+      'api::documentation-section.documentation-section',
+      'title'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::documentation-section.documentation-section',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::documentation-section.documentation-section',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiDocumentationTopicDocumentationTopic
+  extends Schema.CollectionType {
+  collectionName: 'documentation_topics';
+  info: {
+    singularName: 'documentation-topic';
+    pluralName: 'documentation-topics';
+    displayName: 'Documentation Topic';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    content: Attribute.RichText;
+    creation_date: Attribute.Date;
+    title: Attribute.String & Attribute.Required;
+    description: Attribute.Text;
+    slug: Attribute.UID<
+      'api::documentation-topic.documentation-topic',
+      'title'
+    > &
+      Attribute.Required;
+    documentation_sections: Attribute.Relation<
+      'api::documentation-topic.documentation-topic',
+      'oneToMany',
+      'api::documentation-section.documentation-section'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::documentation-topic.documentation-topic',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::documentation-topic.documentation-topic',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+
+
 export interface ApiGlobalGlobal extends Schema.SingleType {
   collectionName: 'globals';
   info: {
@@ -1078,6 +1201,9 @@ declare module '@strapi/types' {
       'api::blog-post-topic.blog-post-topic': ApiBlogPostTopicBlogPostTopic;
       'api::blog-post-type.blog-post-type': ApiBlogPostTypeBlogPostType;
       'api::chat-feedback-modal.chat-feedback-modal': ApiChatFeedbackModalChatFeedbackModal;
+      'api::documentation.documentation': ApiDocumentationDocumentation;
+      'api::documentation-section.documentation-section': ApiDocumentationSectionDocumentationSection;
+      'api::documentation-topic.documentation-topic': ApiDocumentationTopicDocumentationTopic;
       'api::global.global': ApiGlobalGlobal;
     }
   }


### PR DESCRIPTION
This PR is one of multiple that will be associated with PDFCLOUD-2953.


Adds three types:

- **Documentation** (single type)
- **Documentation Topic** (collection type)
- **Documentation Section** (collection type)

**Documentation** should be the catch-all for the header of the /documentation page, and is intended to hold the SEO metadata.

**Documentation Topics** are intended to be the parent sections (Cloud API, Self-Hosted API, etc.)

**Documentation Sections** are for any other section under an existing Documentation Topic or Documentation Section. **These can be nested, and thus can include relations to other Documentation Sections.**