### PR TITLE
Add publish_date to API Tool

### DIFF
--- a/src/api/api-tool/content-types/api-tool/schema.json
+++ b/src/api/api-tool/content-types/api-tool/schema.json
@@ -88,6 +88,10 @@
       "components": [
         "shared.faq"
       ]
+    },
+    "publish_date": {
+      "type": "datetime",
+      "default": "2024-08-29T05:00:00.000Z"
     }
   }
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -24,6 +24,24 @@ export interface ToolCard extends Schema.Component {
   };
 }
 
+export interface HeaderLink extends Schema.Component {
+  collectionName: 'components_header_links';
+  info: {
+    displayName: 'Link';
+    icon: 'link';
+    description: '';
+  };
+  attributes: {
+    label: Attribute.String;
+    description: Attribute.String;
+    to: Attribute.String;
+    icon: Attribute.String;
+    external: Attribute.Boolean;
+    target: Attribute.Enumeration<['_blank']>;
+    children: Attribute.JSON;
+  };
+}
+
 export interface SharedString extends Schema.Component {
   collectionName: 'components_shared_strings';
   info: {
@@ -121,29 +139,12 @@ export interface SharedFaq extends Schema.Component {
   };
 }
 
-export interface HeaderLink extends Schema.Component {
-  collectionName: 'components_header_links';
-  info: {
-    displayName: 'Link';
-    icon: 'link';
-    description: '';
-  };
-  attributes: {
-    label: Attribute.String;
-    description: Attribute.String;
-    to: Attribute.String;
-    icon: Attribute.String;
-    external: Attribute.Boolean;
-    target: Attribute.Enumeration<['_blank']>;
-    children: Attribute.JSON;
-  };
-}
-
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
       'tool.parameter': ToolParameter;
       'tool.card': ToolCard;
+      'header.link': HeaderLink;
       'shared.string': SharedString;
       'shared.slider': SharedSlider;
       'shared.seo': SharedSeo;
@@ -152,7 +153,6 @@ declare module '@strapi/types' {
       'shared.media': SharedMedia;
       'shared.html': SharedHtml;
       'shared.faq': SharedFaq;
-      'header.link': HeaderLink;
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -866,6 +866,8 @@ export interface ApiApiToolApiTool extends Schema.CollectionType {
     slug: Attribute.UID<'api::api-tool.api-tool', 'name'>;
     seo: Attribute.Component<'shared.seo'>;
     faq: Attribute.DynamicZone<['shared.faq']>;
+    publish_date: Attribute.DateTime &
+      Attribute.DefaultTo<'2024-08-29T05:00:00.000Z'>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
This provides a `publish_date` field to sort on for API Tools so that tools can be ordered by date, and the order can be customized like we currently do in Ghost.