### PR TITLE
Add API Tools Bucket relation, developers column to global object

### DIFF
--- a/src/api/pdfrest-global/content-types/pdfrest-global/schema.json
+++ b/src/api/pdfrest-global/content-types/pdfrest-global/schema.json
@@ -22,6 +22,17 @@
       "type": "component",
       "repeatable": false,
       "component": "shared.seo"
+    },
+    "api_tool_buckets": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::api-tool-bucket.api-tool-bucket"
+    },
+    "footer_developers": {
+      "type": "dynamiczone",
+      "components": [
+        "header.link"
+      ]
     }
   }
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -1,31 +1,5 @@
 import type { Schema, Attribute } from '@strapi/strapi';
 
-export interface ToolParameter extends Schema.Component {
-  collectionName: 'components_tool_parameters';
-  info: {
-    displayName: 'Parameter';
-    icon: 'apps';
-    description: '';
-  };
-  attributes: {
-    name: Attribute.String;
-    description: Attribute.RichText;
-    highlighted_parameter: Attribute.Boolean & Attribute.DefaultTo<false>;
-  };
-}
-
-export interface ToolCard extends Schema.Component {
-  collectionName: 'components_tool_cards';
-  info: {
-    displayName: 'Card';
-    description: '';
-  };
-  attributes: {
-    title: Attribute.String;
-    body: Attribute.RichText;
-  };
-}
-
 export interface SharedString extends Schema.Component {
   collectionName: 'components_shared_strings';
   info: {
@@ -123,6 +97,50 @@ export interface SharedFaq extends Schema.Component {
   };
 }
 
+export interface HeaderLink extends Schema.Component {
+  collectionName: 'components_header_links';
+  info: {
+    displayName: 'Link';
+    icon: 'link';
+    description: '';
+  };
+  attributes: {
+    label: Attribute.String;
+    description: Attribute.String;
+    to: Attribute.String;
+    icon: Attribute.String;
+    external: Attribute.Boolean;
+    target: Attribute.Enumeration<['_blank']>;
+    children: Attribute.JSON;
+  };
+}
+
+export interface ToolParameter extends Schema.Component {
+  collectionName: 'components_tool_parameters';
+  info: {
+    displayName: 'Parameter';
+    icon: 'apps';
+    description: '';
+  };
+  attributes: {
+    name: Attribute.String;
+    description: Attribute.RichText;
+    highlighted_parameter: Attribute.Boolean & Attribute.DefaultTo<false>;
+  };
+}
+
+export interface ToolCard extends Schema.Component {
+  collectionName: 'components_tool_cards';
+  info: {
+    displayName: 'Card';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    body: Attribute.RichText;
+  };
+}
+
 export interface PricingFeature extends Schema.Component {
   collectionName: 'components_pricing_features';
   info: {
@@ -153,29 +171,9 @@ export interface PricingCard extends Schema.Component {
   };
 }
 
-export interface HeaderLink extends Schema.Component {
-  collectionName: 'components_header_links';
-  info: {
-    displayName: 'Link';
-    icon: 'link';
-    description: '';
-  };
-  attributes: {
-    label: Attribute.String;
-    description: Attribute.String;
-    to: Attribute.String;
-    icon: Attribute.String;
-    external: Attribute.Boolean;
-    target: Attribute.Enumeration<['_blank']>;
-    children: Attribute.JSON;
-  };
-}
-
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
-      'tool.parameter': ToolParameter;
-      'tool.card': ToolCard;
       'shared.string': SharedString;
       'shared.slider': SharedSlider;
       'shared.seo': SharedSeo;
@@ -184,9 +182,11 @@ declare module '@strapi/types' {
       'shared.media': SharedMedia;
       'shared.html': SharedHtml;
       'shared.faq': SharedFaq;
+      'header.link': HeaderLink;
+      'tool.parameter': ToolParameter;
+      'tool.card': ToolCard;
       'pricing.feature': PricingFeature;
       'pricing.card': PricingCard;
-      'header.link': HeaderLink;
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1349,6 +1349,12 @@ export interface ApiPdfrestGlobalPdfrestGlobal extends Schema.SingleType {
   attributes: {
     nav: Attribute.DynamicZone<['header.link']>;
     seo: Attribute.Component<'shared.seo'>;
+    api_tool_buckets: Attribute.Relation<
+      'api::pdfrest-global.pdfrest-global',
+      'oneToMany',
+      'api::api-tool-bucket.api-tool-bucket'
+    >;
+    footer_developers: Attribute.DynamicZone<['header.link']>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
* Allows populating API Tools from the global object instead of making a separate call to fetch them
* Adds a zone for the developer column of the footer links