### PR TITLE
PDFCLOUD-5666 | Add links to API Toolkit hero element

### DIFF
--- a/src/components/api-toolkit/hero.json
+++ b/src/components/api-toolkit/hero.json
@@ -24,6 +24,16 @@
       "type": "component",
       "repeatable": true,
       "component": "api-toolkit.meta"
+    },
+    "primaryAction": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.link"
+    },
+    "secondaryAction": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.link"
     }
   }
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -79,6 +79,8 @@ export interface ApiToolkitHero extends Schema.Component {
     description: Attribute.Text;
     eyebrow: Attribute.String;
     meta: Attribute.Component<'api-toolkit.meta', true>;
+    primaryAction: Attribute.Component<'shared.link'>;
+    secondaryAction: Attribute.Component<'shared.link'>;
     titleAccent: Attribute.String;
     titleLeading: Attribute.String;
   };


### PR DESCRIPTION
PDFCLOUD-5666

Follow up to #47, add missing elements

- [x] Added `primaryAction` and `secondaryAction` to Hero element