### PR TITLE
PDFCLOUD-5666 | Remove unused attribute, add `bestFor` attribute

### DIFF
--- a/src/components/api-toolkit/deployment-card.json
+++ b/src/components/api-toolkit/deployment-card.json
@@ -34,11 +34,11 @@
       "repeatable": false,
       "component": "shared.link"
     },
-    "backgroundLetter": {
-      "type": "string"
-    },
     "featured": {
       "type": "boolean"
+    },
+    "bestFor": {
+      "type": "string"
     }
   }
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -42,7 +42,7 @@ export interface ApiToolkitDeploymentCard extends Schema.Component {
     displayName: 'Deployment Card';
   };
   attributes: {
-    backgroundLetter: Attribute.String;
+    bestFor: Attribute.String;
     description: Attribute.Text;
     featured: Attribute.Boolean;
     features: Attribute.Component<'api-toolkit.card-feature', true>;


### PR DESCRIPTION
PDFCLOUD-5666

This is a follow up to #47 and #48 

- Removed unused `backgroundLetter` attribute
- Added new `bestFor` attribute