### PR TITLE
PDFCLOUD-5666 | Add fields for missing elements

### DIFF
--- a/src/api/pdfrest-api-toolkit/content-types/pdfrest-api-toolkit/schema.json
+++ b/src/api/pdfrest-api-toolkit/content-types/pdfrest-api-toolkit/schema.json
@@ -36,6 +36,12 @@
       "type": "component",
       "repeatable": true,
       "component": "api-toolkit.deployment-card"
+    },
+    "securityBadgeTitle": {
+      "type": "string"
+    },
+    "trustedByTitle": {
+      "type": "string"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -983,7 +983,9 @@ export interface ApiPdfrestApiToolkitPdfrestApiToolkit
     heroContent: Attribute.Component<'api-toolkit.hero'>;
     midPageCtaContent: Attribute.Component<'api-toolkit.cta'>;
     publishedAt: Attribute.DateTime;
+    securityBadgeTitle: Attribute.String;
     securityComplianceContent: Attribute.Component<'api-toolkit.security-compliance-content'>;
+    trustedByTitle: Attribute.String;
     updatedAt: Attribute.DateTime;
     updatedBy: Attribute.Relation<
       'api::pdfrest-api-toolkit.pdfrest-api-toolkit',


### PR DESCRIPTION
Final PR follow up to #47, #48, and #49 

- Added `securityBadgeTitle` and `trustedByTitle`, which were accidentally hard-coded