### PR TITLE
PDFCLOUD-5902 Add Pdfassistant HTML page content type

### DIFF
--- a/docs/pdfassistant-html-page-ai-guide.md
+++ b/docs/pdfassistant-html-page-ai-guide.md
@@ -1,0 +1,204 @@
+# Pdfassistant HTML Page AI Authoring Guide
+
+Use this guide when generating content for the `Pdfassistant HTML Page` collection type in Strapi.
+
+Your output must match the field structure exactly and must avoid full-document HTML.
+
+## Objective
+
+Generate content for these fields:
+
+- `title`
+- `slug`
+- `page_type`
+- `html_head`
+- `html_body`
+- `structured_data`
+- `seo`
+
+## Required Content Model
+
+### `title`
+
+- Purpose: internal tracking and search inside Strapi
+- Output: short human-readable page name
+- Examples:
+  - `MCP Servers Overview`
+  - `Claude`
+
+### `slug`
+
+- Purpose: page URL segment
+- Output: lowercase kebab-case string without slashes
+- Example:
+  - `press-ready-pdf-x`
+- Rule for overview pages:
+  - Return an empty value when the page is an overview page
+  - Example: `/integrations/mcp-servers` overview should have a blank slug
+
+### `page_type`
+
+- Must be one of:
+  - `features`
+  - `use-cases`
+  - `integrations`
+  - `mcp-servers`
+  - `plugins`
+  - `api`
+
+Choose the closest matching category and do not invent new values.
+
+### `html_head`
+
+- Purpose: content to inject into the page `<head>`
+- Strapi storage note:
+  - This is stored in the component field’s nested `body` value
+- Allowed content:
+  - `<link>`
+  - `<style>`
+  - `<script>`
+- Allowed but unnecessary:
+  - `<head>` wrapper, which will be ignored
+- Do not include:
+  - `<html>`
+  - `<body>`
+  - `<title>`
+  - `<meta>`
+- Styling rules:
+  - Keep CSS scoped to the custom page content
+  - Do not style site navigation
+  - Do not style site footer
+  - Do not add global resets that could affect the rest of the site
+
+Reason:
+
+- Duplicate `<title>` and `<meta>` tags can hurt SEO.
+- Nav/footer CSS can break shared site layout.
+
+### `html_body`
+
+- Purpose: visible page HTML
+- Strapi storage note:
+  - This is stored in the component field’s nested `body` value
+- Output only the body content fragment
+- Allowed but unnecessary:
+  - `<body>` wrapper, which will be ignored
+- Do not include:
+  - `<html>`
+  - `<head>`
+  - document-level wrappers for a full page export
+- Prefer:
+  - semantic sections
+  - headings
+  - paragraphs
+  - lists
+  - CTA blocks
+  - cards or feature sections where useful
+
+Assume all page-specific styling must be supported by the CSS in `html_head`.
+
+### `structured_data`
+
+- Purpose: JSON-LD schema markup injected into the `<head>`
+- Output format: raw JSON only
+- Do not include:
+  - `<script>` tags
+  - HTML
+  - comments
+- Use an appropriate schema type for the page, such as:
+  - `WebPage`
+  - `SoftwareApplication`
+  - `FAQPage`
+  - `HowTo`
+
+### `seo`
+
+- Output as an object with:
+  - `metaTitle`
+  - `metaDescription`
+- Optional:
+  - `canonicalUrl`
+  - `shareImage`
+
+Guidance:
+
+- `metaTitle` should be specific, keyword-aware, and readable.
+- `metaDescription` should summarize the page clearly and naturally.
+
+## Authoring Rules
+
+1. Never generate a full HTML document.
+2. Separate head content from body content.
+3. Exclude duplicate SEO tags from generated HTML.
+4. Do not include nav or footer styling in CSS.
+5. Keep output easy for a human editor to paste into Strapi.
+6. Leave `slug` blank for overview pages.
+7. Use valid JSON for `structured_data`.
+8. Use only the allowed `page_type` enum values.
+
+## Recommended Output Format
+
+Return the content as human-pasteable field sections, not as one JSON object.
+
+Example:
+
+```text
+title
+Claude
+
+slug
+claude
+
+page_type
+integrations
+
+html_head
+<style>
+  /* page-specific styles only */
+</style>
+
+html_body
+<section>
+  <h1>Claude Integration</h1>
+  <p>...</p>
+</section>
+
+structured_data
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Claude Integration"
+}
+
+seo.metaTitle
+Claude Integration for PDF Workflows | pdfassistant
+
+seo.metaDescription
+Learn how Claude works with pdfassistant for AI-powered PDF workflows.
+```
+
+## Validation Checklist
+
+Before returning content, confirm:
+
+- `title` is useful for internal search
+- `slug` is blank only for overview pages
+- `slug` uses kebab-case when present
+- `page_type` is valid
+- `html_head` contains no `<title>` or `<meta>`
+- `html_head` may include `<script>` tags if they are intentional
+- `html_head` contains no nav/footer styling
+- `html_body` is a fragment, not a full page document
+- `structured_data` is valid JSON-LD
+- `seo.metaTitle` and `seo.metaDescription` are present
+
+## Bad Output Patterns
+
+Avoid these:
+
+- Full HTML export with `<!DOCTYPE html>`
+- CSS targeting `header`, `nav`, `footer`, or global site wrappers
+- `<meta name="description">` inside `html_head`
+- `<title>` inside `html_head`
+- `<script type="application/ld+json">` inside `structured_data`
+- A non-empty slug for an overview page

--- a/docs/pdfassistant-html-page-marketing-guide.md
+++ b/docs/pdfassistant-html-page-marketing-guide.md
@@ -1,0 +1,298 @@
+# Pdfassistant HTML Page Entry Guide
+
+This guide explains how to fill out a `Pdfassistant HTML Page` entry in Strapi.
+
+Use it when you are creating a new page for sections such as:
+
+- `features`
+- `use-cases`
+- `integrations`
+- `mcp-servers`
+- `plugins`
+- `api`
+
+The goal is simple: enter the page details clearly, keep the HTML clean, and avoid anything that could hurt SEO or site styling.
+
+## Before You Start
+
+Each entry has two jobs:
+
+1. Define where the page belongs.
+2. Provide the HTML and SEO content for that page.
+
+You do **not** need to build a full website page. Only provide the pieces requested in each field.
+
+## Field-By-Field Instructions
+
+### `title`
+
+What it is:
+An internal name for finding the entry later in Strapi.
+
+How to fill it in:
+
+- Use a clear, human-readable title.
+- Write something you can search for easily later.
+- Match the topic of the page.
+
+Good examples:
+
+- `MCP Servers Overview`
+- `Claude`
+- `Press Ready PDF X`
+
+Best practice:
+
+- Treat this as an internal label, not the URL.
+- Keep it descriptive and specific.
+
+### `slug`
+
+What it is:
+The URL part for the page.
+
+How it works:
+
+- If the slug is `press-ready-pdf-x`, the final URL will be:
+  `pdfassistant.ai/.../press-ready-pdf-x`
+- The frontend will handle the parent section of the URL.
+
+How to fill it in:
+
+- Use lowercase letters.
+- Use hyphens between words.
+- Do not use spaces.
+- Do not add leading or trailing slashes.
+
+Example:
+
+- `press-ready-pdf-x`
+
+When to leave it blank:
+
+- Leave `slug` blank for overview pages.
+- Example: if the page is the main `/integrations/mcp-servers` overview page, leave it blank.
+
+Quick rule:
+
+- Detail page: add a slug.
+- Overview page: leave it blank.
+
+### `page_type`
+
+What it is:
+The section this page belongs to.
+
+Allowed values:
+
+- `features`
+- `use-cases`
+- `integrations`
+- `mcp-servers`
+- `plugins`
+- `api`
+
+How to choose:
+
+- Pick the option that best matches the page topic.
+- Use `mcp-servers` for MCP server pages.
+- Use `plugins` for plugin pages.
+- Use `use-cases` for workflow or scenario pages.
+
+### `html_head`
+
+What it is:
+HTML that will be inserted into the page’s `<head>` section.
+
+What you will see in Strapi:
+
+- Open the `html_head` field.
+- Paste the code into its nested `body` field.
+
+What usually goes here:
+
+- `<link>` tags
+- `<style>` tags
+- `<script>` tags when needed
+
+What to paste:
+
+- Only the code meant for the `<head>`, not a full HTML document.
+
+Important rules:
+
+- A `<head>` wrapper is allowed, but it will be ignored.
+- Do **not** paste a full HTML document.
+- Do **not** include `<title>` tags.
+- Do **not** include `<meta>` tags.
+- Do **not** include nav or footer styling.
+- Keep styles focused on the custom content area for this page.
+
+Why this matters:
+
+- Duplicate `<title>` and `<meta>` tags can create SEO problems.
+- Nav and footer styles can accidentally break the site header and footer.
+
+Good use cases for `html_head`:
+
+- Page-specific CSS
+- Font or stylesheet links that page content needs
+- Supporting scripts that belong in the page head
+
+What to avoid:
+
+- Global site styling
+- Header styling
+- Footer styling
+- SEO tags
+
+### `html_body`
+
+What it is:
+The actual HTML content shown on the page.
+
+What you will see in Strapi:
+
+- Open the `html_body` field.
+- Paste the code into its nested `body` field.
+
+What to paste:
+
+- Only the HTML for the content section of the page.
+- This is the visible page content.
+
+Important rules:
+
+- Do **not** paste a full HTML document.
+- A `<body>` wrapper is allowed, but it will be ignored.
+- Do **not** include `<html>` or `<head>` tags.
+- Assume page styling should come from the custom styles placed in `html_head`.
+
+Best practice:
+
+- Use clean, section-based HTML.
+- Keep the content readable and organized.
+- Use headings, paragraphs, lists, buttons, cards, and sections as needed.
+
+Helpful reminder:
+
+- If the content looks unstyled, the needed CSS probably belongs in `html_head`.
+
+### `structured_data`
+
+What it is:
+Schema markup in JSON-LD format.
+
+How it is used:
+
+- This will be injected into the page as:
+  `<script type="application/ld+json">...</script>`
+- It will appear in the page `<head>`.
+
+What to paste:
+
+- Valid JSON only.
+- Usually schema markup such as `WebPage`, `SoftwareApplication`, `FAQPage`, `HowTo`, or other relevant schema types.
+
+Important rules:
+
+- Do not paste HTML here.
+- Do not include the `<script>` tag yourself.
+- Paste only the raw JSON-LD object.
+
+Best practice:
+
+- Match the schema type to the page content.
+- Keep it accurate and specific to the page.
+
+### `seo`
+
+What it is:
+The SEO settings for the page.
+
+This object includes:
+
+- `metaTitle`
+- `metaDescription`
+- optionally `shareImage`
+- optionally `canonicalUrl`
+
+How to fill it in:
+
+#### `metaTitle`
+
+- Write the SEO page title.
+- Keep it clear and specific.
+- Focus on the keyword/topic and user intent.
+
+Example:
+
+- `Claude Integration for PDF Workflows | pdfassistant`
+
+#### `metaDescription`
+
+- Write a short summary of what the page offers.
+- Make it useful for search results.
+- Keep it natural and readable.
+
+Example:
+
+- `Learn how to use Claude with pdfassistant to automate PDF workflows, document handling, and AI-powered file processing.`
+
+#### `shareImage`
+
+- Optional.
+- Add a social sharing image if one is available and appropriate.
+
+#### `canonicalUrl`
+
+- Optional unless there is a known canonical requirement.
+- Use when the page needs a specific canonical URL.
+
+## Simple Entry Checklist
+
+Before publishing, confirm:
+
+- `title` is clear and searchable.
+- `slug` is filled in for detail pages and blank for overview pages.
+- `page_type` matches the page category.
+- `html_head` contains only head-related code.
+- `html_head` does not include duplicate SEO tags.
+- `html_head` does not include nav/footer styling.
+- `html_head` may include `<script>` tags when needed.
+- `html_body` contains only the visible page content.
+- `structured_data` is valid JSON-LD only.
+- `seo.metaTitle` and `seo.metaDescription` are filled in.
+
+## Common Mistakes to Avoid
+
+- Pasting a full HTML page into `html_head` or `html_body`
+- Adding `<title>` or `<meta>` tags to generated HTML
+- Styling the site navigation or footer inside page CSS
+- Filling in a slug for an overview page that should not have one
+- Pasting HTML into `structured_data`
+- Leaving SEO fields empty
+
+## Example: Overview Page
+
+- `title`: `MCP Servers Overview`
+- `slug`: leave blank
+- `page_type`: `mcp-servers`
+
+## Example: Detail Page
+
+- `title`: `Claude`
+- `slug`: `claude`
+- `page_type`: `integrations`
+
+## Re-Use Rule
+
+If you are unsure what belongs in a field, use this shortcut:
+
+- Search/organization name: `title`
+- URL piece: `slug`
+- Section/category: `page_type`
+- Styles and head links: `html_head`
+- Visible page content: `html_body`
+- Schema markup: `structured_data`
+- Search result title and description: `seo`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "my-app-name",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@retikolo/drag-drop-content-types": "^1.7.1",
@@ -20,6 +21,7 @@
         "fs-extra": "^10.0.0",
         "lodash.set": "^4.3.2",
         "mime-types": "^2.1.27",
+        "patch-package": "^8.0.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "5.3.4",
@@ -6213,6 +6215,11 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -7289,15 +7296,41 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dependencies": {
-        "es-define-property": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
         "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8857,6 +8890,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -8981,12 +9027,9 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "engines": {
         "node": ">= 0.4"
       }
@@ -9003,6 +9046,17 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
       "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw=="
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.19.11",
@@ -9990,6 +10044,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/findup-sync": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
@@ -10538,15 +10600,20 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10598,6 +10665,18 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stdin": {
@@ -10835,11 +10914,11 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11119,21 +11198,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -12241,11 +12309,34 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "peer": true
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -12267,6 +12358,14 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -12375,6 +12474,14 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -13144,6 +13251,14 @@
       "dependencies": {
         "@babel/runtime": "^7.23.8",
         "remove-accents": "0.5.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdurl": {
@@ -14043,6 +14158,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/object-path": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
@@ -14509,6 +14632,79 @@
       "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/path-case": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "fs-extra": "^10.0.0",
     "lodash.set": "^4.3.2",
     "mime-types": "^2.1.27",
+    "patch-package": "^8.0.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "5.3.4",
@@ -27,7 +28,8 @@
     "develop": "strapi develop",
     "start": "strapi start",
     "build": "strapi build",
-    "strapi": "strapi"
+    "strapi": "strapi",
+    "postinstall": "patch-package"
   },
   "author": {
     "name": "A Strapi developer"

--- a/patches/strapi-plugin-import-export-entries+1.23.1.patch
+++ b/patches/strapi-plugin-import-export-entries+1.23.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/strapi-plugin-import-export-entries/admin/src/hooks/useSlug.js b/node_modules/strapi-plugin-import-export-entries/admin/src/hooks/useSlug.js
+index 3d206c9..24d3866 100644
+--- a/node_modules/strapi-plugin-import-export-entries/admin/src/hooks/useSlug.js
++++ b/node_modules/strapi-plugin-import-export-entries/admin/src/hooks/useSlug.js
+@@ -7,7 +7,7 @@ export const useSlug = () => {
+   const { pathname } = useLocation();
+ 
+   const slug = useMemo(() => {
+-    const matches = pathname.match(/content-manager\/(collectionType|singleType)\/([a-zA-Z0-9\-:_.]*)/);
++    const matches = pathname.match(/content-manager\/(collectionType|singleType|collection-types|single-types)\/([a-zA-Z0-9\-:_.]*)/);
+     return matches?.[2] ? matches[2] : SLUG_WHOLE_DB;
+   }, [pathname]);
+ 

--- a/src/api/pdfassistant-html-page/content-types/pdfassistant-html-page/schema.json
+++ b/src/api/pdfassistant-html-page/content-types/pdfassistant-html-page/schema.json
@@ -1,0 +1,50 @@
+{
+  "kind": "collectionType",
+  "collectionName": "pdfassistant_html_pages",
+  "info": {
+    "singularName": "pdfassistant-html-page",
+    "pluralName": "pdfassistant-html-pages",
+    "displayName": "Pdfassistant HTML Page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "slug": {
+      "type": "string"
+    },
+    "page_type": {
+      "type": "enumeration",
+      "enum": [
+        "features",
+        "use-cases",
+        "integrations",
+        "mcp-servers",
+        "plugins",
+        "api"
+      ]
+    },
+    "html_head": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.html"
+    },
+    "html_body": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.html"
+    },
+    "structured_data": {
+      "type": "json"
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.seo"
+    }
+  }
+}

--- a/src/api/pdfassistant-html-page/controllers/pdfassistant-html-page.js
+++ b/src/api/pdfassistant-html-page/controllers/pdfassistant-html-page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * pdfassistant-html-page controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::pdfassistant-html-page.pdfassistant-html-page');

--- a/src/api/pdfassistant-html-page/routes/pdfassistant-html-page.js
+++ b/src/api/pdfassistant-html-page/routes/pdfassistant-html-page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * pdfassistant-html-page router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::pdfassistant-html-page.pdfassistant-html-page');

--- a/src/api/pdfassistant-html-page/services/pdfassistant-html-page.js
+++ b/src/api/pdfassistant-html-page/services/pdfassistant-html-page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * pdfassistant-html-page service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::pdfassistant-html-page.pdfassistant-html-page');

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -1,453 +1,90 @@
-import type { Attribute, Schema } from '@strapi/strapi';
+import type { Schema, Attribute } from '@strapi/strapi';
 
-export interface ApiToolkitCardFeature extends Schema.Component {
-  collectionName: 'components_api_toolkit_card_features';
+export interface ToolParameter extends Schema.Component {
+  collectionName: 'components_tool_parameters';
   info: {
-    displayName: 'Card Feature';
-  };
-  attributes: {
-    highlighted: Attribute.Boolean;
-    text: Attribute.String;
-  };
-}
-
-export interface ApiToolkitComparisonTable extends Schema.Component {
-  collectionName: 'components_api_toolkit_comparison_tables';
-  info: {
-    displayName: 'Comparison Table';
-  };
-  attributes: {
-    content: Attribute.JSON;
-    header: Attribute.String;
-  };
-}
-
-export interface ApiToolkitCta extends Schema.Component {
-  collectionName: 'components_api_toolkit_ctas';
-  info: {
-    displayName: 'CTA';
-  };
-  attributes: {
-    description: Attribute.Text;
-    primaryAction: Attribute.Component<'shared.link'>;
-    secondaryAction: Attribute.Component<'shared.link'>;
-    title: Attribute.String;
-  };
-}
-
-export interface ApiToolkitDeploymentCard extends Schema.Component {
-  collectionName: 'components_api_toolkit_deployment_cards';
-  info: {
+    displayName: 'Parameter';
+    icon: 'apps';
     description: '';
-    displayName: 'Deployment Card';
   };
   attributes: {
-    bestFor: Attribute.String;
-    description: Attribute.Text;
-    featured: Attribute.Boolean;
-    features: Attribute.Component<'api-toolkit.card-feature', true>;
     name: Attribute.String;
-    primaryAction: Attribute.Component<'shared.link'>;
-    secondaryAction: Attribute.Component<'shared.link'>;
-    subtitle: Attribute.String;
-    tag: Attribute.String;
+    description: Attribute.RichText;
+    highlighted_parameter: Attribute.Boolean & Attribute.DefaultTo<false>;
   };
 }
 
-export interface ApiToolkitDeploymentContent extends Schema.Component {
-  collectionName: 'components_api_toolkit_deployment_contents';
+export interface ToolCard extends Schema.Component {
+  collectionName: 'components_tool_cards';
   info: {
-    displayName: 'Deployment Content';
-  };
-  attributes: {
-    description: Attribute.Text;
-    eyebrow: Attribute.String;
-    titleAccent: Attribute.String;
-    titleLeading: Attribute.String;
-    titleTrailing: Attribute.String;
-  };
-}
-
-export interface ApiToolkitHero extends Schema.Component {
-  collectionName: 'components_api_toolkit_heroes';
-  info: {
+    displayName: 'Card';
     description: '';
-    displayName: 'Hero';
-    icon: 'alien';
   };
   attributes: {
-    description: Attribute.Text;
-    eyebrow: Attribute.String;
-    meta: Attribute.Component<'api-toolkit.meta', true>;
-    primaryAction: Attribute.Component<'shared.link'>;
-    secondaryAction: Attribute.Component<'shared.link'>;
-    titleAccent: Attribute.String;
-    titleLeading: Attribute.String;
+    title: Attribute.String;
+    body: Attribute.RichText;
   };
 }
 
-export interface ApiToolkitMeta extends Schema.Component {
-  collectionName: 'components_api_toolkit_metas';
+export interface SharedString extends Schema.Component {
+  collectionName: 'components_shared_strings';
   info: {
-    displayName: 'meta';
+    displayName: 'String';
   };
   attributes: {
     text: Attribute.String;
   };
 }
 
-export interface ApiToolkitSecurityComplianceContent extends Schema.Component {
-  collectionName: 'components_api_toolkit_security_compliance_contents';
+export interface SharedSlider extends Schema.Component {
+  collectionName: 'components_shared_sliders';
   info: {
-    displayName: 'Security Compliance Content';
-    icon: 'shield';
-  };
-  attributes: {
-    comparisonTable: Attribute.Component<'api-toolkit.comparison-table'>;
-    credentials: Attribute.Component<'shared.card', true>;
-    description: Attribute.Text;
-    eyebrow: Attribute.String;
-    primaryAction: Attribute.Component<'shared.link'>;
-    secondaryAction: Attribute.Component<'shared.link'>;
-    titleAccent: Attribute.String;
-    titleLeading: Attribute.String;
-    titleTrailing: Attribute.String;
-  };
-}
-
-export interface DocumentationDocSection extends Schema.Component {
-  collectionName: 'components_documentation_doc_sections';
-  info: {
-    displayName: 'Doc Section';
-    icon: 'file';
-  };
-  attributes: {
-    description: Attribute.RichText;
-    links: Attribute.Component<'header.link', true>;
-    tabs: Attribute.Component<'tool.parameter', true>;
-    text_content: Attribute.RichText;
-    title: Attribute.String;
-  };
-}
-
-export interface FaqFaqSection extends Schema.Component {
-  collectionName: 'components_faq_faq_sections';
-  info: {
+    displayName: 'Slider';
+    icon: 'address-book';
     description: '';
-    displayName: 'FAQ Section';
-    icon: 'question';
   };
   attributes: {
-    questions: Attribute.Component<'faq.question', true>;
-    title: Attribute.String;
+    files: Attribute.Media<'images', true>;
   };
 }
 
-export interface FaqQuestion extends Schema.Component {
-  collectionName: 'components_faq_questions';
+export interface SharedSeo extends Schema.Component {
+  collectionName: 'components_shared_seos';
   info: {
-    displayName: 'Question';
-    icon: 'question';
-  };
-  attributes: {
-    body: Attribute.RichText;
-    title: Attribute.String;
-  };
-}
-
-export interface HeaderLink extends Schema.Component {
-  collectionName: 'components_header_links';
-  info: {
+    name: 'Seo';
+    icon: 'allergies';
+    displayName: 'Seo';
     description: '';
-    displayName: 'Link';
-    icon: 'link';
   };
   attributes: {
-    children: Attribute.JSON;
-    description: Attribute.String;
-    external: Attribute.Boolean;
-    icon: Attribute.String;
-    label: Attribute.String;
-    target: Attribute.Enumeration<['_blank']>;
-    to: Attribute.String;
+    metaTitle: Attribute.String & Attribute.Required;
+    metaDescription: Attribute.Text & Attribute.Required;
+    shareImage: Attribute.Media<'images'>;
+    canonicalUrl: Attribute.String;
   };
 }
 
-export interface PricingSectionCta extends Schema.Component {
-  collectionName: 'components_pricing_section_ctas';
+export interface SharedRichText extends Schema.Component {
+  collectionName: 'components_shared_rich_texts';
   info: {
+    displayName: 'Markdown';
+    icon: 'strikeThrough';
     description: '';
-    displayName: 'CTA';
-    icon: 'magic';
-  };
-  attributes: {
-    description: Attribute.Text;
-    link: Attribute.Component<'pricing-section.pricing-link', true>;
-    title: Attribute.String;
-  };
-}
-
-export interface PricingSectionDynamicCta extends Schema.Component {
-  collectionName: 'components_pricing_section_dynamic_ctas';
-  info: {
-    description: '';
-    displayName: 'Dynamic CTA';
-    icon: 'phone';
-  };
-  attributes: {
-    condition: Attribute.Enumeration<
-      ['no_account', 'is_starter', 'is_premium_or_pro', 'is_enterprise']
-    >;
-    description: Attribute.RichText;
-    icon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    iconify_icon_name: Attribute.String;
-    title: Attribute.String;
-  };
-}
-
-export interface PricingSectionFeature extends Schema.Component {
-  collectionName: 'components_pricing_section_features';
-  info: {
-    description: '';
-    displayName: 'Feature';
-    icon: 'check';
-  };
-  attributes: {
-    description: Attribute.RichText;
-    icon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    iconify_icon: Attribute.String;
-    title: Attribute.String;
-  };
-}
-
-export interface PricingSectionPricingFeatures extends Schema.Component {
-  collectionName: 'components_pricing_section_pricing_features';
-  info: {
-    displayName: 'Pricing Features';
-    icon: 'bulletList';
-  };
-  attributes: {
-    feature: Attribute.Component<'pricing-section.feature', true>;
-    title: Attribute.String;
-  };
-}
-
-export interface PricingSectionPricingLink extends Schema.Component {
-  collectionName: 'components_pricing_section_pricing_links';
-  info: {
-    description: '';
-    displayName: 'Pricing Link';
-    icon: 'link';
-  };
-  attributes: {
-    external: Attribute.Boolean;
-    title: Attribute.String;
-    url: Attribute.String;
-  };
-}
-
-export interface PricingSectionPricingSection extends Schema.Component {
-  collectionName: 'components_pricing_section_pricing_sections';
-  info: {
-    description: '';
-    displayName: 'Section Header';
-    icon: 'expand';
-  };
-  attributes: {
-    body: Attribute.RichText;
-    description: Attribute.Text;
-    description_link: Attribute.Component<'pricing-section.pricing-link'>;
-    title: Attribute.String;
-    title_image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-  };
-}
-
-export interface PricingCard extends Schema.Component {
-  collectionName: 'components_pricing_cards';
-  info: {
-    description: '';
-    displayName: 'card';
-    icon: 'priceTag';
-  };
-  attributes: {
-    badge_text: Attribute.String;
-    cycle: Attribute.String;
-    description: Attribute.Text;
-    discount_text: Attribute.String;
-    discounted_price: Attribute.String;
-    features: Attribute.Component<'pricing.feature', true>;
-    highlight: Attribute.Boolean;
-    price: Attribute.String;
-    price_data: Attribute.JSON;
-    stripe_data: Attribute.JSON;
-    title: Attribute.String;
-    user_state: Attribute.JSON;
-  };
-}
-
-export interface PricingFeature extends Schema.Component {
-  collectionName: 'components_pricing_features';
-  info: {
-    description: '';
-    displayName: 'Feature';
-    icon: 'check';
-  };
-  attributes: {
-    detail: Attribute.String;
-  };
-}
-
-export interface ProductPdfassistantProductSection extends Schema.Component {
-  collectionName: 'components_product_pdfassistant_product_sections';
-  info: {
-    description: '';
-    displayName: 'Section';
-    icon: 'apps';
-  };
-  attributes: {
-    align: Attribute.Enumeration<['left', 'center', 'right']>;
-    card_style: Attribute.Enumeration<['landing']>;
-    cards: Attribute.Component<'shared.card', true>;
-    description: Attribute.RichText;
-    features: Attribute.Component<'shared.card', true>;
-    full_width: Attribute.Boolean;
-    icon: Attribute.String;
-    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    links: Attribute.Component<'shared.link', true>;
-    overrides: Attribute.JSON;
-    pricing_cards: Attribute.JSON;
-    subsections: Attribute.JSON;
-    title: Attribute.String;
-  };
-}
-
-export interface ProductPluginsGroup extends Schema.Component {
-  collectionName: 'components_product_plugins_groups';
-  info: {
-    description: '';
-    displayName: 'Plugins Group';
-    icon: 'apps';
-  };
-  attributes: {
-    description: Attribute.RichText;
-    pdfassistant_products: Attribute.Relation<
-      'product.plugins-group',
-      'oneToMany',
-      'api::pdfassistant-product.pdfassistant-product'
-    >;
-    title: Attribute.String;
-  };
-}
-
-export interface ProductToolGroup extends Schema.Component {
-  collectionName: 'components_product_tool_groups';
-  info: {
-    displayName: 'Tool Group';
-    icon: 'apps';
-  };
-  attributes: {
-    api_tools: Attribute.Relation<
-      'product.tool-group',
-      'oneToMany',
-      'api::api-tool.api-tool'
-    >;
-    description: Attribute.RichText;
-    title: Attribute.String;
-  };
-}
-
-export interface SharedCard extends Schema.Component {
-  collectionName: 'components_shared_cards';
-  info: {
-    description: '';
-    displayName: 'Card';
-    icon: 'dashboard';
-  };
-  attributes: {
-    badge: Attribute.String;
-    description: Attribute.RichText;
-    icon: Attribute.String;
-    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    title: Attribute.String;
-  };
-}
-
-export interface SharedContentSection extends Schema.Component {
-  collectionName: 'components_shared_content_sections';
-  info: {
-    displayName: 'Content Section';
-    icon: 'bulletList';
-  };
-  attributes: {
-    align: Attribute.Enumeration<['left', 'center', 'right']>;
-    card_style: Attribute.Enumeration<['landing']>;
-    cards: Attribute.Component<'shared.card', true>;
-    description: Attribute.RichText;
-    features: Attribute.Component<'shared.card', true>;
-    full_width: Attribute.Boolean;
-    icon: Attribute.String;
-    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    links: Attribute.Component<'shared.link', true>;
-    overrides: Attribute.JSON;
-    pricing_cards: Attribute.JSON;
-    subsections: Attribute.JSON;
-    title: Attribute.String;
-  };
-}
-
-export interface SharedCta extends Schema.Component {
-  collectionName: 'components_shared_ctas';
-  info: {
-    description: '';
-    displayName: 'CTA';
-    icon: 'cursor';
-  };
-  attributes: {
-    description: Attribute.RichText;
-    links: Attribute.Component<'header.link', true>;
-    stateful: Attribute.Boolean;
-    title: Attribute.String;
-  };
-}
-
-export interface SharedFaq extends Schema.Component {
-  collectionName: 'components_shared_faqs';
-  info: {
-    displayName: 'FAQ';
-    icon: 'question';
-  };
-  attributes: {
-    content: Attribute.RichText;
-    label: Attribute.String;
-  };
-}
-
-export interface SharedHtml extends Schema.Component {
-  collectionName: 'components_shared_htmls';
-  info: {
-    description: '';
-    displayName: 'HTML';
-    icon: 'code';
   };
   attributes: {
     body: Attribute.RichText;
   };
 }
 
-export interface SharedLink extends Schema.Component {
-  collectionName: 'components_shared_links';
+export interface SharedQuote extends Schema.Component {
+  collectionName: 'components_shared_quotes';
   info: {
-    displayName: 'Link';
-    icon: 'link';
+    displayName: 'Quote';
+    icon: 'indent';
   };
   attributes: {
-    children: Attribute.JSON;
-    description: Attribute.String;
-    external: Attribute.Boolean;
-    icon: Attribute.String;
-    label: Attribute.String;
-    target: Attribute.Enumeration<['_blank']>;
-    to: Attribute.String;
+    title: Attribute.String;
+    body: Attribute.Text;
   };
 }
 
@@ -462,134 +99,497 @@ export interface SharedMedia extends Schema.Component {
   };
 }
 
-export interface SharedQuote extends Schema.Component {
-  collectionName: 'components_shared_quotes';
+export interface SharedLink extends Schema.Component {
+  collectionName: 'components_shared_links';
   info: {
-    displayName: 'Quote';
-    icon: 'indent';
+    displayName: 'Link';
+    icon: 'link';
   };
   attributes: {
-    body: Attribute.Text;
-    title: Attribute.String;
+    label: Attribute.String;
+    description: Attribute.String;
+    to: Attribute.String;
+    icon: Attribute.String;
+    external: Attribute.Boolean;
+    target: Attribute.Enumeration<['_blank']>;
+    children: Attribute.JSON;
   };
 }
 
-export interface SharedRichText extends Schema.Component {
-  collectionName: 'components_shared_rich_texts';
+export interface SharedHtml extends Schema.Component {
+  collectionName: 'components_shared_htmls';
   info: {
+    displayName: 'HTML';
+    icon: 'code';
     description: '';
-    displayName: 'Markdown';
-    icon: 'strikeThrough';
   };
   attributes: {
     body: Attribute.RichText;
   };
 }
 
-export interface SharedSeo extends Schema.Component {
-  collectionName: 'components_shared_seos';
+export interface SharedFaq extends Schema.Component {
+  collectionName: 'components_shared_faqs';
   info: {
-    description: '';
-    displayName: 'Seo';
-    icon: 'allergies';
-    name: 'Seo';
+    displayName: 'FAQ';
+    icon: 'question';
   };
   attributes: {
-    canonicalUrl: Attribute.String;
-    metaDescription: Attribute.Text & Attribute.Required;
-    metaTitle: Attribute.String & Attribute.Required;
-    shareImage: Attribute.Media<'images'>;
+    label: Attribute.String;
+    content: Attribute.RichText;
   };
 }
 
-export interface SharedSlider extends Schema.Component {
-  collectionName: 'components_shared_sliders';
+export interface SharedCta extends Schema.Component {
+  collectionName: 'components_shared_ctas';
   info: {
+    displayName: 'CTA';
+    icon: 'cursor';
     description: '';
-    displayName: 'Slider';
-    icon: 'address-book';
   };
   attributes: {
-    files: Attribute.Media<'images', true>;
+    title: Attribute.String;
+    description: Attribute.RichText;
+    links: Attribute.Component<'header.link', true>;
+    stateful: Attribute.Boolean;
   };
 }
 
-export interface SharedString extends Schema.Component {
-  collectionName: 'components_shared_strings';
+export interface SharedContentSection extends Schema.Component {
+  collectionName: 'components_shared_content_sections';
   info: {
-    displayName: 'String';
+    displayName: 'Content Section';
+    icon: 'bulletList';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    align: Attribute.Enumeration<['left', 'center', 'right']>;
+    card_style: Attribute.Enumeration<['landing']>;
+    icon: Attribute.String;
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    full_width: Attribute.Boolean;
+    features: Attribute.Component<'shared.card', true>;
+    cards: Attribute.Component<'shared.card', true>;
+    links: Attribute.Component<'shared.link', true>;
+    pricing_cards: Attribute.JSON;
+    subsections: Attribute.JSON;
+    overrides: Attribute.JSON;
+  };
+}
+
+export interface SharedCard extends Schema.Component {
+  collectionName: 'components_shared_cards';
+  info: {
+    displayName: 'Card';
+    icon: 'dashboard';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    icon: Attribute.String;
+    badge: Attribute.String;
+  };
+}
+
+export interface ProductToolGroup extends Schema.Component {
+  collectionName: 'components_product_tool_groups';
+  info: {
+    displayName: 'Tool Group';
+    icon: 'apps';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    api_tools: Attribute.Relation<
+      'product.tool-group',
+      'oneToMany',
+      'api::api-tool.api-tool'
+    >;
+  };
+}
+
+export interface ProductPluginsGroup extends Schema.Component {
+  collectionName: 'components_product_plugins_groups';
+  info: {
+    displayName: 'Plugins Group';
+    icon: 'apps';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    pdfassistant_products: Attribute.Relation<
+      'product.plugins-group',
+      'oneToMany',
+      'api::pdfassistant-product.pdfassistant-product'
+    >;
+  };
+}
+
+export interface ProductPdfassistantProductSection extends Schema.Component {
+  collectionName: 'components_product_pdfassistant_product_sections';
+  info: {
+    displayName: 'Section';
+    icon: 'apps';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    align: Attribute.Enumeration<['left', 'center', 'right']>;
+    features: Attribute.Component<'shared.card', true>;
+    cards: Attribute.Component<'shared.card', true>;
+    full_width: Attribute.Boolean;
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    subsections: Attribute.JSON;
+    overrides: Attribute.JSON;
+    pricing_cards: Attribute.JSON;
+    links: Attribute.Component<'shared.link', true>;
+    icon: Attribute.String;
+    card_style: Attribute.Enumeration<['landing']>;
+  };
+}
+
+export interface PricingSectionPricingSection extends Schema.Component {
+  collectionName: 'components_pricing_section_pricing_sections';
+  info: {
+    displayName: 'Section Header';
+    icon: 'expand';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    body: Attribute.RichText;
+    description_link: Attribute.Component<'pricing-section.pricing-link'>;
+    title_image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+  };
+}
+
+export interface PricingSectionPricingLink extends Schema.Component {
+  collectionName: 'components_pricing_section_pricing_links';
+  info: {
+    displayName: 'Pricing Link';
+    icon: 'link';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    url: Attribute.String;
+    external: Attribute.Boolean;
+  };
+}
+
+export interface PricingSectionPricingFeatures extends Schema.Component {
+  collectionName: 'components_pricing_section_pricing_features';
+  info: {
+    displayName: 'Pricing Features';
+    icon: 'bulletList';
+  };
+  attributes: {
+    title: Attribute.String;
+    feature: Attribute.Component<'pricing-section.feature', true>;
+  };
+}
+
+export interface PricingSectionFeature extends Schema.Component {
+  collectionName: 'components_pricing_section_features';
+  info: {
+    displayName: 'Feature';
+    icon: 'check';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    icon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    description: Attribute.RichText;
+    iconify_icon: Attribute.String;
+  };
+}
+
+export interface PricingSectionDynamicCta extends Schema.Component {
+  collectionName: 'components_pricing_section_dynamic_ctas';
+  info: {
+    displayName: 'Dynamic CTA';
+    icon: 'phone';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    condition: Attribute.Enumeration<
+      ['no_account', 'is_starter', 'is_premium_or_pro', 'is_enterprise']
+    >;
+    icon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    iconify_icon_name: Attribute.String;
+  };
+}
+
+export interface PricingSectionCta extends Schema.Component {
+  collectionName: 'components_pricing_section_ctas';
+  info: {
+    displayName: 'CTA';
+    icon: 'magic';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    link: Attribute.Component<'pricing-section.pricing-link', true>;
+  };
+}
+
+export interface PricingFeature extends Schema.Component {
+  collectionName: 'components_pricing_features';
+  info: {
+    displayName: 'Feature';
+    icon: 'check';
+    description: '';
+  };
+  attributes: {
+    detail: Attribute.String;
+  };
+}
+
+export interface PricingCard extends Schema.Component {
+  collectionName: 'components_pricing_cards';
+  info: {
+    displayName: 'card';
+    icon: 'priceTag';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    features: Attribute.Component<'pricing.feature', true>;
+    price: Attribute.String;
+    discounted_price: Attribute.String;
+    user_state: Attribute.JSON;
+    discount_text: Attribute.String;
+    highlight: Attribute.Boolean;
+    badge_text: Attribute.String;
+    cycle: Attribute.String;
+    stripe_data: Attribute.JSON;
+    price_data: Attribute.JSON;
+  };
+}
+
+export interface HeaderLink extends Schema.Component {
+  collectionName: 'components_header_links';
+  info: {
+    displayName: 'Link';
+    icon: 'link';
+    description: '';
+  };
+  attributes: {
+    label: Attribute.String;
+    description: Attribute.String;
+    to: Attribute.String;
+    icon: Attribute.String;
+    external: Attribute.Boolean;
+    target: Attribute.Enumeration<['_blank']>;
+    children: Attribute.JSON;
+  };
+}
+
+export interface FaqQuestion extends Schema.Component {
+  collectionName: 'components_faq_questions';
+  info: {
+    displayName: 'Question';
+    icon: 'question';
+  };
+  attributes: {
+    title: Attribute.String;
+    body: Attribute.RichText;
+  };
+}
+
+export interface FaqFaqSection extends Schema.Component {
+  collectionName: 'components_faq_faq_sections';
+  info: {
+    displayName: 'FAQ Section';
+    icon: 'question';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String;
+    questions: Attribute.Component<'faq.question', true>;
+  };
+}
+
+export interface DocumentationDocSection extends Schema.Component {
+  collectionName: 'components_documentation_doc_sections';
+  info: {
+    displayName: 'Doc Section';
+    icon: 'file';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    text_content: Attribute.RichText;
+    tabs: Attribute.Component<'tool.parameter', true>;
+    links: Attribute.Component<'header.link', true>;
+  };
+}
+
+export interface ApiToolkitSecurityComplianceContent extends Schema.Component {
+  collectionName: 'components_api_toolkit_security_compliance_contents';
+  info: {
+    displayName: 'Security Compliance Content';
+    icon: 'shield';
+  };
+  attributes: {
+    eyebrow: Attribute.String;
+    titleLeading: Attribute.String;
+    titleAccent: Attribute.String;
+    titleTrailing: Attribute.String;
+    description: Attribute.Text;
+    primaryAction: Attribute.Component<'shared.link'>;
+    secondaryAction: Attribute.Component<'shared.link'>;
+    credentials: Attribute.Component<'shared.card', true>;
+    comparisonTable: Attribute.Component<'api-toolkit.comparison-table'>;
+  };
+}
+
+export interface ApiToolkitMeta extends Schema.Component {
+  collectionName: 'components_api_toolkit_metas';
+  info: {
+    displayName: 'meta';
   };
   attributes: {
     text: Attribute.String;
   };
 }
 
-export interface ToolCard extends Schema.Component {
-  collectionName: 'components_tool_cards';
+export interface ApiToolkitHero extends Schema.Component {
+  collectionName: 'components_api_toolkit_heroes';
   info: {
+    displayName: 'Hero';
+    icon: 'alien';
     description: '';
-    displayName: 'Card';
   };
   attributes: {
-    body: Attribute.RichText;
-    title: Attribute.String;
+    eyebrow: Attribute.String;
+    titleLeading: Attribute.String;
+    titleAccent: Attribute.String;
+    description: Attribute.Text;
+    meta: Attribute.Component<'api-toolkit.meta', true>;
+    primaryAction: Attribute.Component<'shared.link'>;
+    secondaryAction: Attribute.Component<'shared.link'>;
   };
 }
 
-export interface ToolParameter extends Schema.Component {
-  collectionName: 'components_tool_parameters';
+export interface ApiToolkitDeploymentContent extends Schema.Component {
+  collectionName: 'components_api_toolkit_deployment_contents';
   info: {
-    description: '';
-    displayName: 'Parameter';
-    icon: 'apps';
+    displayName: 'Deployment Content';
   };
   attributes: {
-    description: Attribute.RichText;
-    highlighted_parameter: Attribute.Boolean & Attribute.DefaultTo<false>;
+    eyebrow: Attribute.String;
+    titleLeading: Attribute.String;
+    titleAccent: Attribute.String;
+    titleTrailing: Attribute.String;
+    description: Attribute.Text;
+  };
+}
+
+export interface ApiToolkitDeploymentCard extends Schema.Component {
+  collectionName: 'components_api_toolkit_deployment_cards';
+  info: {
+    displayName: 'Deployment Card';
+    description: '';
+  };
+  attributes: {
+    tag: Attribute.String;
     name: Attribute.String;
+    subtitle: Attribute.String;
+    description: Attribute.Text;
+    features: Attribute.Component<'api-toolkit.card-feature', true>;
+    primaryAction: Attribute.Component<'shared.link'>;
+    secondaryAction: Attribute.Component<'shared.link'>;
+    featured: Attribute.Boolean;
+    bestFor: Attribute.String;
+  };
+}
+
+export interface ApiToolkitCta extends Schema.Component {
+  collectionName: 'components_api_toolkit_ctas';
+  info: {
+    displayName: 'CTA';
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    primaryAction: Attribute.Component<'shared.link'>;
+    secondaryAction: Attribute.Component<'shared.link'>;
+  };
+}
+
+export interface ApiToolkitComparisonTable extends Schema.Component {
+  collectionName: 'components_api_toolkit_comparison_tables';
+  info: {
+    displayName: 'Comparison Table';
+  };
+  attributes: {
+    header: Attribute.String;
+    content: Attribute.JSON;
+  };
+}
+
+export interface ApiToolkitCardFeature extends Schema.Component {
+  collectionName: 'components_api_toolkit_card_features';
+  info: {
+    displayName: 'Card Feature';
+  };
+  attributes: {
+    text: Attribute.String;
+    highlighted: Attribute.Boolean;
   };
 }
 
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
-      'api-toolkit.card-feature': ApiToolkitCardFeature;
-      'api-toolkit.comparison-table': ApiToolkitComparisonTable;
-      'api-toolkit.cta': ApiToolkitCta;
-      'api-toolkit.deployment-card': ApiToolkitDeploymentCard;
-      'api-toolkit.deployment-content': ApiToolkitDeploymentContent;
-      'api-toolkit.hero': ApiToolkitHero;
-      'api-toolkit.meta': ApiToolkitMeta;
-      'api-toolkit.security-compliance-content': ApiToolkitSecurityComplianceContent;
-      'documentation.doc-section': DocumentationDocSection;
-      'faq.faq-section': FaqFaqSection;
-      'faq.question': FaqQuestion;
-      'header.link': HeaderLink;
-      'pricing-section.cta': PricingSectionCta;
-      'pricing-section.dynamic-cta': PricingSectionDynamicCta;
-      'pricing-section.feature': PricingSectionFeature;
-      'pricing-section.pricing-features': PricingSectionPricingFeatures;
-      'pricing-section.pricing-link': PricingSectionPricingLink;
-      'pricing-section.pricing-section': PricingSectionPricingSection;
-      'pricing.card': PricingCard;
-      'pricing.feature': PricingFeature;
-      'product.pdfassistant-product-section': ProductPdfassistantProductSection;
-      'product.plugins-group': ProductPluginsGroup;
-      'product.tool-group': ProductToolGroup;
-      'shared.card': SharedCard;
-      'shared.content-section': SharedContentSection;
-      'shared.cta': SharedCta;
-      'shared.faq': SharedFaq;
-      'shared.html': SharedHtml;
-      'shared.link': SharedLink;
-      'shared.media': SharedMedia;
-      'shared.quote': SharedQuote;
-      'shared.rich-text': SharedRichText;
-      'shared.seo': SharedSeo;
-      'shared.slider': SharedSlider;
-      'shared.string': SharedString;
-      'tool.card': ToolCard;
       'tool.parameter': ToolParameter;
+      'tool.card': ToolCard;
+      'shared.string': SharedString;
+      'shared.slider': SharedSlider;
+      'shared.seo': SharedSeo;
+      'shared.rich-text': SharedRichText;
+      'shared.quote': SharedQuote;
+      'shared.media': SharedMedia;
+      'shared.link': SharedLink;
+      'shared.html': SharedHtml;
+      'shared.faq': SharedFaq;
+      'shared.cta': SharedCta;
+      'shared.content-section': SharedContentSection;
+      'shared.card': SharedCard;
+      'product.tool-group': ProductToolGroup;
+      'product.plugins-group': ProductPluginsGroup;
+      'product.pdfassistant-product-section': ProductPdfassistantProductSection;
+      'pricing-section.pricing-section': PricingSectionPricingSection;
+      'pricing-section.pricing-link': PricingSectionPricingLink;
+      'pricing-section.pricing-features': PricingSectionPricingFeatures;
+      'pricing-section.feature': PricingSectionFeature;
+      'pricing-section.dynamic-cta': PricingSectionDynamicCta;
+      'pricing-section.cta': PricingSectionCta;
+      'pricing.feature': PricingFeature;
+      'pricing.card': PricingCard;
+      'header.link': HeaderLink;
+      'faq.question': FaqQuestion;
+      'faq.faq-section': FaqFaqSection;
+      'documentation.doc-section': DocumentationDocSection;
+      'api-toolkit.security-compliance-content': ApiToolkitSecurityComplianceContent;
+      'api-toolkit.meta': ApiToolkitMeta;
+      'api-toolkit.hero': ApiToolkitHero;
+      'api-toolkit.deployment-content': ApiToolkitDeploymentContent;
+      'api-toolkit.deployment-card': ApiToolkitDeploymentCard;
+      'api-toolkit.cta': ApiToolkitCta;
+      'api-toolkit.comparison-table': ApiToolkitComparisonTable;
+      'api-toolkit.card-feature': ApiToolkitCardFeature;
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1,120 +1,13 @@
-import type { Attribute, Schema } from '@strapi/strapi';
-
-export interface AdminApiToken extends Schema.CollectionType {
-  collectionName: 'strapi_api_tokens';
-  info: {
-    description: '';
-    displayName: 'Api Token';
-    name: 'Api Token';
-    pluralName: 'api-tokens';
-    singularName: 'api-token';
-  };
-  pluginOptions: {
-    'content-manager': {
-      visible: false;
-    };
-    'content-type-builder': {
-      visible: false;
-    };
-  };
-  attributes: {
-    accessKey: Attribute.String &
-      Attribute.Required &
-      Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'admin::api-token',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.String &
-      Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }> &
-      Attribute.DefaultTo<''>;
-    expiresAt: Attribute.DateTime;
-    lastUsedAt: Attribute.DateTime;
-    lifespan: Attribute.BigInteger;
-    name: Attribute.String &
-      Attribute.Required &
-      Attribute.Unique &
-      Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    permissions: Attribute.Relation<
-      'admin::api-token',
-      'oneToMany',
-      'admin::api-token-permission'
-    >;
-    type: Attribute.Enumeration<['read-only', 'full-access', 'custom']> &
-      Attribute.Required &
-      Attribute.DefaultTo<'read-only'>;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'admin::api-token',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface AdminApiTokenPermission extends Schema.CollectionType {
-  collectionName: 'strapi_api_token_permissions';
-  info: {
-    description: '';
-    displayName: 'API Token Permission';
-    name: 'API Token Permission';
-    pluralName: 'api-token-permissions';
-    singularName: 'api-token-permission';
-  };
-  pluginOptions: {
-    'content-manager': {
-      visible: false;
-    };
-    'content-type-builder': {
-      visible: false;
-    };
-  };
-  attributes: {
-    action: Attribute.String &
-      Attribute.Required &
-      Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'admin::api-token-permission',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    token: Attribute.Relation<
-      'admin::api-token-permission',
-      'manyToOne',
-      'admin::api-token'
-    >;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'admin::api-token-permission',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
+import type { Schema, Attribute } from '@strapi/strapi';
 
 export interface AdminPermission extends Schema.CollectionType {
   collectionName: 'admin_permissions';
   info: {
-    description: '';
-    displayName: 'Permission';
     name: 'Permission';
-    pluralName: 'permissions';
+    description: '';
     singularName: 'permission';
+    pluralName: 'permissions';
+    displayName: 'Permission';
   };
   pluginOptions: {
     'content-manager': {
@@ -131,26 +24,83 @@ export interface AdminPermission extends Schema.CollectionType {
         minLength: 1;
       }>;
     actionParameters: Attribute.JSON & Attribute.DefaultTo<{}>;
+    subject: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    properties: Attribute.JSON & Attribute.DefaultTo<{}>;
     conditions: Attribute.JSON & Attribute.DefaultTo<[]>;
+    role: Attribute.Relation<'admin::permission', 'manyToOne', 'admin::role'>;
     createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
       'admin::permission',
       'oneToOne',
       'admin::user'
     > &
       Attribute.Private;
-    properties: Attribute.JSON & Attribute.DefaultTo<{}>;
-    role: Attribute.Relation<'admin::permission', 'manyToOne', 'admin::role'>;
-    subject: Attribute.String &
-      Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    updatedAt: Attribute.DateTime;
     updatedBy: Attribute.Relation<
       'admin::permission',
       'oneToOne',
       'admin::user'
     > &
+      Attribute.Private;
+  };
+}
+
+export interface AdminUser extends Schema.CollectionType {
+  collectionName: 'admin_users';
+  info: {
+    name: 'User';
+    description: '';
+    singularName: 'user';
+    pluralName: 'users';
+    displayName: 'User';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    firstname: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    lastname: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    username: Attribute.String;
+    email: Attribute.Email &
+      Attribute.Required &
+      Attribute.Private &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    password: Attribute.Password &
+      Attribute.Private &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    resetPasswordToken: Attribute.String & Attribute.Private;
+    registrationToken: Attribute.String & Attribute.Private;
+    isActive: Attribute.Boolean &
+      Attribute.Private &
+      Attribute.DefaultTo<false>;
+    roles: Attribute.Relation<'admin::user', 'manyToMany', 'admin::role'> &
+      Attribute.Private;
+    blocked: Attribute.Boolean & Attribute.Private & Attribute.DefaultTo<false>;
+    preferedLanguage: Attribute.String;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::user', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'admin::user', 'oneToOne', 'admin::user'> &
       Attribute.Private;
   };
 }
@@ -158,11 +108,11 @@ export interface AdminPermission extends Schema.CollectionType {
 export interface AdminRole extends Schema.CollectionType {
   collectionName: 'admin_roles';
   info: {
-    description: '';
-    displayName: 'Role';
     name: 'Role';
-    pluralName: 'roles';
+    description: '';
     singularName: 'role';
+    pluralName: 'roles';
+    displayName: 'Role';
   };
   pluginOptions: {
     'content-manager': {
@@ -173,42 +123,42 @@ export interface AdminRole extends Schema.CollectionType {
     };
   };
   attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     code: Attribute.String &
       Attribute.Required &
       Attribute.Unique &
       Attribute.SetMinMaxLength<{
         minLength: 1;
       }>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<'admin::role', 'oneToOne', 'admin::user'> &
-      Attribute.Private;
     description: Attribute.String;
-    name: Attribute.String &
-      Attribute.Required &
-      Attribute.Unique &
-      Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    users: Attribute.Relation<'admin::role', 'manyToMany', 'admin::user'>;
     permissions: Attribute.Relation<
       'admin::role',
       'oneToMany',
       'admin::permission'
     >;
+    createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::role', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
     updatedBy: Attribute.Relation<'admin::role', 'oneToOne', 'admin::user'> &
       Attribute.Private;
-    users: Attribute.Relation<'admin::role', 'manyToMany', 'admin::user'>;
   };
 }
 
-export interface AdminTransferToken extends Schema.CollectionType {
-  collectionName: 'strapi_transfer_tokens';
+export interface AdminApiToken extends Schema.CollectionType {
+  collectionName: 'strapi_api_tokens';
   info: {
+    name: 'Api Token';
+    singularName: 'api-token';
+    pluralName: 'api-tokens';
+    displayName: 'Api Token';
     description: '';
-    displayName: 'Transfer Token';
-    name: 'Transfer Token';
-    pluralName: 'transfer-tokens';
-    singularName: 'transfer-token';
   };
   pluginOptions: {
     'content-manager': {
@@ -219,40 +169,43 @@ export interface AdminTransferToken extends Schema.CollectionType {
     };
   };
   attributes: {
-    accessKey: Attribute.String &
-      Attribute.Required &
-      Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'admin::transfer-token',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.String &
-      Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }> &
-      Attribute.DefaultTo<''>;
-    expiresAt: Attribute.DateTime;
-    lastUsedAt: Attribute.DateTime;
-    lifespan: Attribute.BigInteger;
     name: Attribute.String &
       Attribute.Required &
       Attribute.Unique &
       Attribute.SetMinMaxLength<{
         minLength: 1;
       }>;
+    description: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }> &
+      Attribute.DefaultTo<''>;
+    type: Attribute.Enumeration<['read-only', 'full-access', 'custom']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'read-only'>;
+    accessKey: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    lastUsedAt: Attribute.DateTime;
     permissions: Attribute.Relation<
-      'admin::transfer-token',
+      'admin::api-token',
       'oneToMany',
-      'admin::transfer-token-permission'
+      'admin::api-token-permission'
     >;
+    expiresAt: Attribute.DateTime;
+    lifespan: Attribute.BigInteger;
+    createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'admin::api-token',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
     updatedBy: Attribute.Relation<
-      'admin::transfer-token',
+      'admin::api-token',
       'oneToOne',
       'admin::user'
     > &
@@ -260,14 +213,14 @@ export interface AdminTransferToken extends Schema.CollectionType {
   };
 }
 
-export interface AdminTransferTokenPermission extends Schema.CollectionType {
-  collectionName: 'strapi_transfer_token_permissions';
+export interface AdminApiTokenPermission extends Schema.CollectionType {
+  collectionName: 'strapi_api_token_permissions';
   info: {
+    name: 'API Token Permission';
     description: '';
-    displayName: 'Transfer Token Permission';
-    name: 'Transfer Token Permission';
-    pluralName: 'transfer-token-permissions';
-    singularName: 'transfer-token-permission';
+    singularName: 'api-token-permission';
+    pluralName: 'api-token-permissions';
+    displayName: 'API Token Permission';
   };
   pluginOptions: {
     'content-manager': {
@@ -283,1382 +236,125 @@ export interface AdminTransferTokenPermission extends Schema.CollectionType {
       Attribute.SetMinMaxLength<{
         minLength: 1;
       }>;
+    token: Attribute.Relation<
+      'admin::api-token-permission',
+      'manyToOne',
+      'admin::api-token'
+    >;
     createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
-      'admin::transfer-token-permission',
+      'admin::api-token-permission',
       'oneToOne',
       'admin::user'
     > &
       Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'admin::api-token-permission',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface AdminTransferToken extends Schema.CollectionType {
+  collectionName: 'strapi_transfer_tokens';
+  info: {
+    name: 'Transfer Token';
+    singularName: 'transfer-token';
+    pluralName: 'transfer-tokens';
+    displayName: 'Transfer Token';
+    description: '';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    description: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }> &
+      Attribute.DefaultTo<''>;
+    accessKey: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    lastUsedAt: Attribute.DateTime;
+    permissions: Attribute.Relation<
+      'admin::transfer-token',
+      'oneToMany',
+      'admin::transfer-token-permission'
+    >;
+    expiresAt: Attribute.DateTime;
+    lifespan: Attribute.BigInteger;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'admin::transfer-token',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'admin::transfer-token',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface AdminTransferTokenPermission extends Schema.CollectionType {
+  collectionName: 'strapi_transfer_token_permissions';
+  info: {
+    name: 'Transfer Token Permission';
+    description: '';
+    singularName: 'transfer-token-permission';
+    pluralName: 'transfer-token-permissions';
+    displayName: 'Transfer Token Permission';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     token: Attribute.Relation<
       'admin::transfer-token-permission',
       'manyToOne',
       'admin::transfer-token'
     >;
+    createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
+    createdBy: Attribute.Relation<
       'admin::transfer-token-permission',
       'oneToOne',
       'admin::user'
     > &
       Attribute.Private;
-  };
-}
-
-export interface AdminUser extends Schema.CollectionType {
-  collectionName: 'admin_users';
-  info: {
-    description: '';
-    displayName: 'User';
-    name: 'User';
-    pluralName: 'users';
-    singularName: 'user';
-  };
-  pluginOptions: {
-    'content-manager': {
-      visible: false;
-    };
-    'content-type-builder': {
-      visible: false;
-    };
-  };
-  attributes: {
-    blocked: Attribute.Boolean & Attribute.Private & Attribute.DefaultTo<false>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<'admin::user', 'oneToOne', 'admin::user'> &
-      Attribute.Private;
-    email: Attribute.Email &
-      Attribute.Required &
-      Attribute.Private &
-      Attribute.Unique &
-      Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
-    firstname: Attribute.String &
-      Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    isActive: Attribute.Boolean &
-      Attribute.Private &
-      Attribute.DefaultTo<false>;
-    lastname: Attribute.String &
-      Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
-    password: Attribute.Password &
-      Attribute.Private &
-      Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
-    preferedLanguage: Attribute.String;
-    registrationToken: Attribute.String & Attribute.Private;
-    resetPasswordToken: Attribute.String & Attribute.Private;
-    roles: Attribute.Relation<'admin::user', 'manyToMany', 'admin::role'> &
-      Attribute.Private;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<'admin::user', 'oneToOne', 'admin::user'> &
-      Attribute.Private;
-    username: Attribute.String;
-  };
-}
-
-export interface ApiApiToolBucketApiToolBucket extends Schema.CollectionType {
-  collectionName: 'api_tool_buckets';
-  info: {
-    description: '';
-    displayName: 'API Tool Bucket';
-    pluralName: 'api-tool-buckets';
-    singularName: 'api-tool-bucket';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    api_tools: Attribute.Relation<
-      'api::api-tool-bucket.api-tool-bucket',
-      'oneToMany',
-      'api::api-tool.api-tool'
-    >;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::api-tool-bucket.api-tool-bucket',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.Text;
-    name: Attribute.String;
-    publishedAt: Attribute.DateTime;
-    rank: Attribute.Integer;
-    updatedAt: Attribute.DateTime;
     updatedBy: Attribute.Relation<
-      'api::api-tool-bucket.api-tool-bucket',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiApiToolEndpointApiToolEndpoint
-  extends Schema.CollectionType {
-  collectionName: 'api_tool_endpoints';
-  info: {
-    displayName: 'API Tool Endpoint';
-    pluralName: 'api-tool-endpoints';
-    singularName: 'api-tool-endpoint';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    api_lab_json: Attribute.JSON;
-    api_tool: Attribute.Relation<
-      'api::api-tool-endpoint.api-tool-endpoint',
-      'manyToOne',
-      'api::api-tool.api-tool'
-    >;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::api-tool-endpoint.api-tool-endpoint',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    endpoint: Attribute.String;
-    publishedAt: Attribute.DateTime;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::api-tool-endpoint.api-tool-endpoint',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiApiToolApiTool extends Schema.CollectionType {
-  collectionName: 'api_tools';
-  info: {
-    description: '';
-    displayName: 'API Tool';
-    pluralName: 'api-tools';
-    singularName: 'api-tool';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    api_tool_bucket: Attribute.Relation<
-      'api::api-tool.api-tool',
-      'manyToOne',
-      'api::api-tool-bucket.api-tool-bucket'
-    >;
-    api_tool_endpoints: Attribute.Relation<
-      'api::api-tool.api-tool',
-      'oneToMany',
-      'api::api-tool-endpoint.api-tool-endpoint'
-    >;
-    cloud_only: Attribute.Boolean;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::api-tool.api-tool',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    faq: Attribute.DynamicZone<['shared.faq']>;
-    header_blurb: Attribute.String;
-    icon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    name: Attribute.String;
-    new_tool: Attribute.Boolean;
-    parameters: Attribute.DynamicZone<['tool.parameter']>;
-    pro_tool: Attribute.Boolean;
-    publish_date: Attribute.DateTime &
-      Attribute.DefaultTo<'2024-08-29T05:00:00.000Z'>;
-    publishedAt: Attribute.DateTime;
-    rank: Attribute.Integer;
-    seo: Attribute.Component<'shared.seo'>;
-    slug: Attribute.UID<'api::api-tool.api-tool', 'name'>;
-    tool_card_desc: Attribute.Text;
-    tool_page_desc: Attribute.RichText;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::api-tool.api-tool',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    why_cards: Attribute.DynamicZone<['tool.card']>;
-    why_section_desc: Attribute.Text;
-    why_section_title: Attribute.String;
-    youtube_url: Attribute.String;
-  };
-}
-
-export interface ApiBlogPostTopicBlogPostTopic extends Schema.CollectionType {
-  collectionName: 'blog_post_topics';
-  info: {
-    description: '';
-    displayName: 'Blog Post Topic';
-    pluralName: 'blog-post-topics';
-    singularName: 'blog-post-topic';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    blog_posts: Attribute.Relation<
-      'api::blog-post-topic.blog-post-topic',
-      'manyToMany',
-      'api::blog-post.blog-post'
-    >;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::blog-post-topic.blog-post-topic',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.Text;
-    name: Attribute.String & Attribute.Required;
-    publishedAt: Attribute.DateTime;
-    slug: Attribute.UID<'api::blog-post-topic.blog-post-topic', 'name'> &
-      Attribute.Required;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::blog-post-topic.blog-post-topic',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiBlogPostTypeBlogPostType extends Schema.CollectionType {
-  collectionName: 'blog_post_types';
-  info: {
-    description: '';
-    displayName: 'Blog Post Type';
-    pluralName: 'blog-post-types';
-    singularName: 'blog-post-type';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    blog_posts: Attribute.Relation<
-      'api::blog-post-type.blog-post-type',
-      'oneToMany',
-      'api::blog-post.blog-post'
-    >;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::blog-post-type.blog-post-type',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.Text;
-    icon: Attribute.String;
-    name: Attribute.String;
-    name_plural: Attribute.String;
-    publishedAt: Attribute.DateTime;
-    rank: Attribute.Integer;
-    seo: Attribute.Component<'shared.seo'>;
-    slug: Attribute.UID<'api::blog-post-type.blog-post-type', 'name'>;
-    slug_plural: Attribute.UID<
-      'api::blog-post-type.blog-post-type',
-      'name_plural'
-    >;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::blog-post-type.blog-post-type',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiBlogPostBlogPost extends Schema.CollectionType {
-  collectionName: 'blog_posts';
-  info: {
-    description: '';
-    displayName: 'Blog Post';
-    pluralName: 'blog-posts';
-    singularName: 'blog-post';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    blocks: Attribute.DynamicZone<['shared.rich-text', 'shared.html']>;
-    blog_post_topics: Attribute.Relation<
-      'api::blog-post.blog-post',
-      'manyToMany',
-      'api::blog-post-topic.blog-post-topic'
-    >;
-    blog_post_type: Attribute.Relation<
-      'api::blog-post.blog-post',
-      'manyToOne',
-      'api::blog-post-type.blog-post-type'
-    >;
-    cover: Attribute.Media<'images' | 'files' | 'videos'>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::blog-post.blog-post',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.Text &
-      Attribute.SetMinMaxLength<{
-        maxLength: 80;
-      }>;
-    icon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    publish_date: Attribute.DateTime &
-      Attribute.DefaultTo<'2024-05-14T05:00:01.148Z'>;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    short_title: Attribute.String;
-    slug: Attribute.UID<'api::blog-post.blog-post', 'title'>;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::blog-post.blog-post',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiBlogBlog extends Schema.SingleType {
-  collectionName: 'blogs';
-  info: {
-    displayName: ' Blog';
-    pluralName: 'blogs';
-    singularName: 'blog';
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<'api::blog.blog', 'oneToOne', 'admin::user'> &
-      Attribute.Private;
-    description: Attribute.Text;
-    seo: Attribute.Component<'shared.seo'>;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<'api::blog.blog', 'oneToOne', 'admin::user'> &
-      Attribute.Private;
-  };
-}
-
-export interface ApiChatFeedbackModalChatFeedbackModal
-  extends Schema.SingleType {
-  collectionName: 'chat_feedback_modals';
-  info: {
-    description: '';
-    displayName: 'Chat Feedback Modal';
-    pluralName: 'chat-feedback-modals';
-    singularName: 'chat-feedback-modal';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::chat-feedback-modal.chat-feedback-modal',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    input_placeholder: Attribute.String;
-    prompts: Attribute.Component<'shared.string', true>;
-    publishedAt: Attribute.DateTime;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::chat-feedback-modal.chat-feedback-modal',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiDocumentationSectionDocumentationSection
-  extends Schema.CollectionType {
-  collectionName: 'documentation_sections';
-  info: {
-    description: '';
-    displayName: 'Documentation Section';
-    pluralName: 'documentation-sections';
-    singularName: 'documentation-section';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    content: Attribute.RichText & Attribute.Required;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::documentation-section.documentation-section',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    creation_date: Attribute.Date;
-    description: Attribute.Text;
-    documentation_subsections: Attribute.Relation<
-      'api::documentation-section.documentation-section',
-      'oneToMany',
-      'api::documentation-section.documentation-section'
-    >;
-    publishedAt: Attribute.DateTime;
-    slug: Attribute.UID<
-      'api::documentation-section.documentation-section',
-      'title'
-    >;
-    title: Attribute.String & Attribute.Required;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::documentation-section.documentation-section',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiDocumentationTopicDocumentationTopic
-  extends Schema.CollectionType {
-  collectionName: 'documentation_topics';
-  info: {
-    description: '';
-    displayName: 'Documentation Topic';
-    pluralName: 'documentation-topics';
-    singularName: 'documentation-topic';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    content: Attribute.RichText;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::documentation-topic.documentation-topic',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    creation_date: Attribute.Date;
-    description: Attribute.Text;
-    documentation_sections: Attribute.Relation<
-      'api::documentation-topic.documentation-topic',
-      'oneToMany',
-      'api::documentation-section.documentation-section'
-    >;
-    publishedAt: Attribute.DateTime;
-    slug: Attribute.UID<
-      'api::documentation-topic.documentation-topic',
-      'title'
-    > &
-      Attribute.Required;
-    title: Attribute.String & Attribute.Required;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::documentation-topic.documentation-topic',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiDocumentationDocumentation extends Schema.SingleType {
-  collectionName: 'documentations';
-  info: {
-    displayName: 'Documentation';
-    pluralName: 'documentations';
-    singularName: 'documentation';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::documentation.documentation',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.Text;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::documentation.documentation',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiGlobalGlobal extends Schema.SingleType {
-  collectionName: 'globals';
-  info: {
-    description: 'Define global settings';
-    displayName: 'Global';
-    pluralName: 'globals';
-    singularName: 'global';
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  attributes: {
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::global.global',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    defaultSeo: Attribute.Component<'shared.seo'>;
-    favicon: Attribute.Media<'images' | 'files' | 'videos'>;
-    siteDescription: Attribute.Text & Attribute.Required;
-    siteName: Attribute.String & Attribute.Required;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::global.global',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfassistantPluginsOverviewPdfassistantPluginsOverview
-  extends Schema.SingleType {
-  collectionName: 'pdfassistant_plugins_overviews';
-  info: {
-    description: '';
-    displayName: 'Pdfassistant Plugins Overview';
-    pluralName: 'pdfassistant-plugins-overviews';
-    singularName: 'pdfassistant-plugins-overview';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    content: Attribute.DynamicZone<
-      ['shared.content-section', 'product.plugins-group']
-    >;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfassistant-plugins-overview.pdfassistant-plugins-overview',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    hero: Attribute.Component<'shared.content-section'>;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfassistant-plugins-overview.pdfassistant-plugins-overview',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfassistantPricingPdfassistantPricing
-  extends Schema.SingleType {
-  collectionName: 'pdfassistant_pricings';
-  info: {
-    description: '';
-    displayName: 'Pdfassistant Pricing';
-    pluralName: 'pdfassistant-pricings';
-    singularName: 'pdfassistant-pricing';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfassistant-pricing.pdfassistant-pricing',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    credit_plans: Attribute.DynamicZone<['pricing.card']>;
-    description: Attribute.Text;
-    faq: Attribute.DynamicZone<['shared.faq']>;
-    plan_details_table: Attribute.JSON;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo', true>;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfassistant-pricing.pdfassistant-pricing',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfassistantProductPdfassistantProduct
-  extends Schema.CollectionType {
-  collectionName: 'pdfassistant_products';
-  info: {
-    description: '';
-    displayName: 'Pdfassistant Product';
-    pluralName: 'pdfassistant-products';
-    singularName: 'pdfassistant-product';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    content: Attribute.DynamicZone<['shared.content-section']>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfassistant-product.pdfassistant-product',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.RichText;
-    icon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    slug: Attribute.UID<
-      'api::pdfassistant-product.pdfassistant-product',
-      'title'
-    >;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfassistant-product.pdfassistant-product',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestApiToolkitPdfrestApiToolkit
-  extends Schema.SingleType {
-  collectionName: 'pdfrest_api_toolkits';
-  info: {
-    description: '';
-    displayName: 'Pdfrest API Toolkit';
-    pluralName: 'pdfrest-api-toolkits';
-    singularName: 'pdfrest-api-toolkit';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-api-toolkit.pdfrest-api-toolkit',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    deploymentCards: Attribute.Component<'api-toolkit.deployment-card', true>;
-    deploymentContent: Attribute.Component<'api-toolkit.deployment-content'>;
-    heroContent: Attribute.Component<'api-toolkit.hero'>;
-    midPageCtaContent: Attribute.Component<'api-toolkit.cta'>;
-    publishedAt: Attribute.DateTime;
-    securityBadgeTitle: Attribute.String;
-    securityComplianceContent: Attribute.Component<'api-toolkit.security-compliance-content'>;
-    trustedByTitle: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-api-toolkit.pdfrest-api-toolkit',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestContainerLicenseKeyRequestPdfrestContainerLicenseKeyRequest
-  extends Schema.SingleType {
-  collectionName: 'pdfrest_container_license_key_requests';
-  info: {
-    displayName: 'Pdfrest Container License Key Request';
-    pluralName: 'pdfrest-container-license-key-requests';
-    singularName: 'pdfrest-container-license-key-request';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-container-license-key-request.pdfrest-container-license-key-request',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.RichText;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-container-license-key-request.pdfrest-container-license-key-request',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestDataProcessingAgreementPdfrestDataProcessingAgreement
-  extends Schema.SingleType {
-  collectionName: 'pdfrest_data_processing_agreements';
-  info: {
-    description: '';
-    displayName: 'Pdfrest Data Processing Agreement';
-    pluralName: 'pdfrest-data-processing-agreements';
-    singularName: 'pdfrest-data-processing-agreement';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    body: Attribute.RichText;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-data-processing-agreement.pdfrest-data-processing-agreement',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.Text;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-data-processing-agreement.pdfrest-data-processing-agreement',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestDocumentationPagePdfrestDocumentationPage
-  extends Schema.CollectionType {
-  collectionName: 'pdfrest_documentation_pages';
-  info: {
-    description: '';
-    displayName: 'Pdfrest Documentation Page';
-    pluralName: 'pdfrest-documentation-pages';
-    singularName: 'pdfrest-documentation-page';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    content: Attribute.DynamicZone<
-      [
-        'documentation.doc-section',
-        'shared.rich-text',
-        'shared.html',
-        'shared.card'
-      ]
-    >;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-documentation-page.pdfrest-documentation-page',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.RichText;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    slug: Attribute.UID<
-      'api::pdfrest-documentation-page.pdfrest-documentation-page',
-      'title'
-    >;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-documentation-page.pdfrest-documentation-page',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestGlobalPdfrestGlobal extends Schema.SingleType {
-  collectionName: 'pdfrest_globals';
-  info: {
-    description: '';
-    displayName: 'PdfRest Global';
-    pluralName: 'pdfrest-globals';
-    singularName: 'pdfrest-global';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    api_tool_buckets: Attribute.Relation<
-      'api::pdfrest-global.pdfrest-global',
-      'oneToMany',
-      'api::api-tool-bucket.api-tool-bucket'
-    >;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-global.pdfrest-global',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    footer_developers: Attribute.DynamicZone<['header.link']>;
-    footer_products: Attribute.DynamicZone<['header.link']>;
-    nav: Attribute.DynamicZone<['header.link']>;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    stateful_cta: Attribute.JSON;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-global.pdfrest-global',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestPricingCardPdfrestPricingCard
-  extends Schema.CollectionType {
-  collectionName: 'pdfrest_pricing_cards';
-  info: {
-    description: '';
-    displayName: 'Pdfrest Pricing Card Group';
-    pluralName: 'pdfrest-pricing-cards';
-    singularName: 'pdfrest-pricing-card';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    card: Attribute.Component<'pricing.card', true>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-pricing-card.pdfrest-pricing-card',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    publishedAt: Attribute.DateTime;
-    title: Attribute.String & Attribute.Required & Attribute.Private;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-pricing-card.pdfrest-pricing-card',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestPricingSectionPdfrestPricingSection
-  extends Schema.CollectionType {
-  collectionName: 'pdfrest_pricing_sections';
-  info: {
-    description: '';
-    displayName: 'Pdfrest Pricing Section';
-    pluralName: 'pdfrest-pricing-sections';
-    singularName: 'pdfrest-pricing-section';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-pricing-section.pdfrest-pricing-section',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    cta_link: Attribute.Component<'pricing-section.pricing-link'>;
-    cta_title: Attribute.String;
-    ctas: Attribute.Component<'pricing-section.cta', true>;
-    faq_link: Attribute.Component<'pricing-section.pricing-link'>;
-    features: Attribute.Component<'pricing-section.pricing-features'>;
-    features_table: Attribute.JSON;
-    pdfrest_pricing_card_group: Attribute.Relation<
-      'api::pdfrest-pricing-section.pdfrest-pricing-section',
-      'oneToOne',
-      'api::pdfrest-pricing-card.pdfrest-pricing-card'
-    >;
-    pricing_card_description: Attribute.Text;
-    pricing_card_title: Attribute.String;
-    publishedAt: Attribute.DateTime;
-    section_header: Attribute.Component<'pricing-section.pricing-section'>;
-    Title: Attribute.String & Attribute.Required & Attribute.Private;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-pricing-section.pdfrest-pricing-section',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestPricingPdfrestPricing extends Schema.SingleType {
-  collectionName: 'pdfrest_pricings';
-  info: {
-    description: '';
-    displayName: 'Pdfrest Pricing';
-    pluralName: 'pdfrest-pricings';
-    singularName: 'pdfrest-pricing';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    cloud_faq_link: Attribute.Component<'pricing-section.pricing-link'>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-pricing.pdfrest-pricing',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.RichText;
-    description_cloud: Attribute.RichText;
-    dynamic_cta: Attribute.Component<'pricing-section.dynamic-cta', true>;
-    faq_sections: Attribute.Component<'faq.faq-section', true>;
-    features_table: Attribute.JSON;
-    features_table_title: Attribute.String;
-    image_cloud: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    pdfrest_pricing_card_group: Attribute.Relation<
-      'api::pdfrest-pricing.pdfrest-pricing',
-      'oneToOne',
-      'api::pdfrest-pricing-card.pdfrest-pricing-card'
-    >;
-    pdfrest_pricing_sections: Attribute.Relation<
-      'api::pdfrest-pricing.pdfrest-pricing',
-      'oneToMany',
-      'api::pdfrest-pricing-section.pdfrest-pricing-section'
-    >;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    title: Attribute.String;
-    title_cloud: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-pricing.pdfrest-pricing',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestPrivacyPolicyPdfrestPrivacyPolicy
-  extends Schema.SingleType {
-  collectionName: 'pdfrest_privacy_policies';
-  info: {
-    description: '';
-    displayName: 'Pdfrest Privacy Policy';
-    pluralName: 'pdfrest-privacy-policies';
-    singularName: 'pdfrest-privacy-policy';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    body: Attribute.RichText;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-privacy-policy.pdfrest-privacy-policy',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.Text;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-privacy-policy.pdfrest-privacy-policy',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestProductPdfrestProduct extends Schema.CollectionType {
-  collectionName: 'pdfrest_products';
-  info: {
-    description: '';
-    displayName: 'Pdfrest Product';
-    pluralName: 'pdfrest-products';
-    singularName: 'pdfrest-product';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-product.pdfrest-product',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    cta: Attribute.Component<'shared.cta'>;
-    deployment: Attribute.Component<'shared.content-section'>;
-    description: Attribute.Text;
-    docs_links: Attribute.Component<'header.link', true>;
-    docs_section_description: Attribute.RichText;
-    docs_section_title: Attribute.String;
-    final_cta: Attribute.Component<'shared.cta'>;
-    icon: Attribute.String;
-    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    overview_cards: Attribute.Component<'shared.card', true>;
-    overview_sections: Attribute.Component<'shared.card', true>;
-    pdfrest_pricing_card_group: Attribute.Relation<
-      'api::pdfrest-product.pdfrest-product',
-      'oneToOne',
-      'api::pdfrest-pricing-card.pdfrest-pricing-card'
-    >;
-    pricing_links: Attribute.Component<'header.link', true>;
-    pricing_section_description: Attribute.RichText;
-    pricing_section_title: Attribute.String;
-    pro_tools_description: Attribute.RichText;
-    pro_tools_title: Attribute.String;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    slug: Attribute.UID<'api::pdfrest-product.pdfrest-product', 'title'>;
-    title: Attribute.String;
-    tool_groups: Attribute.Component<'product.tool-group', true>;
-    tools_section_description: Attribute.RichText;
-    tools_section_title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-product.pdfrest-product',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestSecurityCertificationPdfrestSecurityCertification
-  extends Schema.SingleType {
-  collectionName: 'pdfrest_security_certifications';
-  info: {
-    description: '';
-    displayName: 'Pdfrest Security Certification';
-    pluralName: 'pdfrest-security-certifications';
-    singularName: 'pdfrest-security-certification';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    certification_icons: Attribute.Media<
-      'images' | 'files' | 'videos' | 'audios',
-      true
-    >;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-security-certification.pdfrest-security-certification',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.Text;
-    links: Attribute.Component<'pricing-section.pricing-link', true>;
-    publishedAt: Attribute.DateTime;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-security-certification.pdfrest-security-certification',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestSecurityPdfrestSecurity extends Schema.SingleType {
-  collectionName: 'pdfrest_securities';
-  info: {
-    description: '';
-    displayName: 'Pdfrest Security';
-    pluralName: 'pdfrest-securities';
-    singularName: 'pdfrest-security';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    content: Attribute.Component<'product.pdfassistant-product-section', true>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-security.pdfrest-security',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    cta: Attribute.Component<'shared.cta'>;
-    hero: Attribute.Component<'product.pdfassistant-product-section'>;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-security.pdfrest-security',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface ApiPdfrestTermsOfServicePdfrestTermsOfService
-  extends Schema.SingleType {
-  collectionName: 'pdfrest_terms_of_services';
-  info: {
-    description: '';
-    displayName: 'Pdfrest Terms of Service';
-    pluralName: 'pdfrest-terms-of-services';
-    singularName: 'pdfrest-terms-of-service';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    body: Attribute.RichText;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'api::pdfrest-terms-of-service.pdfrest-terms-of-service',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    description: Attribute.Text;
-    publishedAt: Attribute.DateTime;
-    seo: Attribute.Component<'shared.seo'>;
-    title: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'api::pdfrest-terms-of-service.pdfrest-terms-of-service',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface PluginContentReleasesRelease extends Schema.CollectionType {
-  collectionName: 'strapi_releases';
-  info: {
-    displayName: 'Release';
-    pluralName: 'releases';
-    singularName: 'release';
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    'content-manager': {
-      visible: false;
-    };
-    'content-type-builder': {
-      visible: false;
-    };
-  };
-  attributes: {
-    actions: Attribute.Relation<
-      'plugin::content-releases.release',
-      'oneToMany',
-      'plugin::content-releases.release-action'
-    >;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'plugin::content-releases.release',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    name: Attribute.String & Attribute.Required;
-    releasedAt: Attribute.DateTime;
-    scheduledAt: Attribute.DateTime;
-    status: Attribute.Enumeration<
-      ['ready', 'blocked', 'failed', 'done', 'empty']
-    > &
-      Attribute.Required;
-    timezone: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'plugin::content-releases.release',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface PluginContentReleasesReleaseAction
-  extends Schema.CollectionType {
-  collectionName: 'strapi_release_actions';
-  info: {
-    displayName: 'Release Action';
-    pluralName: 'release-actions';
-    singularName: 'release-action';
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    'content-manager': {
-      visible: false;
-    };
-    'content-type-builder': {
-      visible: false;
-    };
-  };
-  attributes: {
-    contentType: Attribute.String & Attribute.Required;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'plugin::content-releases.release-action',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    entry: Attribute.Relation<
-      'plugin::content-releases.release-action',
-      'morphToOne'
-    >;
-    isEntryValid: Attribute.Boolean;
-    locale: Attribute.String;
-    release: Attribute.Relation<
-      'plugin::content-releases.release-action',
-      'manyToOne',
-      'plugin::content-releases.release'
-    >;
-    type: Attribute.Enumeration<['publish', 'unpublish']> & Attribute.Required;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'plugin::content-releases.release-action',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface PluginI18NLocale extends Schema.CollectionType {
-  collectionName: 'i18n_locale';
-  info: {
-    collectionName: 'locales';
-    description: '';
-    displayName: 'Locale';
-    pluralName: 'locales';
-    singularName: 'locale';
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    'content-manager': {
-      visible: false;
-    };
-    'content-type-builder': {
-      visible: false;
-    };
-  };
-  attributes: {
-    code: Attribute.String & Attribute.Unique;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'plugin::i18n.locale',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    name: Attribute.String &
-      Attribute.SetMinMax<
-        {
-          max: 50;
-          min: 1;
-        },
-        number
-      >;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'plugin::i18n.locale',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface PluginPublisherAction extends Schema.CollectionType {
-  collectionName: 'actions';
-  info: {
-    displayName: 'actions';
-    pluralName: 'actions';
-    singularName: 'action';
-  };
-  options: {
-    comment: '';
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    'content-manager': {
-      visible: false;
-    };
-    'content-type-builder': {
-      visible: false;
-    };
-  };
-  attributes: {
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'plugin::publisher.action',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    entityId: Attribute.Integer;
-    entitySlug: Attribute.String;
-    executeAt: Attribute.DateTime;
-    mode: Attribute.String;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'plugin::publisher.action',
+      'admin::transfer-token-permission',
       'oneToOne',
       'admin::user'
     > &
@@ -1669,10 +365,10 @@ export interface PluginPublisherAction extends Schema.CollectionType {
 export interface PluginUploadFile extends Schema.CollectionType {
   collectionName: 'files';
   info: {
-    description: '';
-    displayName: 'File';
-    pluralName: 'files';
     singularName: 'file';
+    pluralName: 'files';
+    displayName: 'File';
+    description: '';
   };
   pluginOptions: {
     'content-manager': {
@@ -1683,16 +379,21 @@ export interface PluginUploadFile extends Schema.CollectionType {
     };
   };
   attributes: {
+    name: Attribute.String & Attribute.Required;
     alternativeText: Attribute.String;
     caption: Attribute.String;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'plugin::upload.file',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
+    width: Attribute.Integer;
+    height: Attribute.Integer;
+    formats: Attribute.JSON;
+    hash: Attribute.String & Attribute.Required;
     ext: Attribute.String;
+    mime: Attribute.String & Attribute.Required;
+    size: Attribute.Decimal & Attribute.Required;
+    url: Attribute.String & Attribute.Required;
+    previewUrl: Attribute.String;
+    provider: Attribute.String & Attribute.Required;
+    provider_metadata: Attribute.JSON;
+    related: Attribute.Relation<'plugin::upload.file', 'morphToMany'>;
     folder: Attribute.Relation<
       'plugin::upload.file',
       'manyToOne',
@@ -1708,34 +409,29 @@ export interface PluginUploadFile extends Schema.CollectionType {
         },
         number
       >;
-    formats: Attribute.JSON;
-    hash: Attribute.String & Attribute.Required;
-    height: Attribute.Integer;
-    mime: Attribute.String & Attribute.Required;
-    name: Attribute.String & Attribute.Required;
-    previewUrl: Attribute.String;
-    provider: Attribute.String & Attribute.Required;
-    provider_metadata: Attribute.JSON;
-    related: Attribute.Relation<'plugin::upload.file', 'morphToMany'>;
-    size: Attribute.Decimal & Attribute.Required;
+    createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::upload.file',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
     updatedBy: Attribute.Relation<
       'plugin::upload.file',
       'oneToOne',
       'admin::user'
     > &
       Attribute.Private;
-    url: Attribute.String & Attribute.Required;
-    width: Attribute.Integer;
   };
 }
 
 export interface PluginUploadFolder extends Schema.CollectionType {
   collectionName: 'upload_folders';
   info: {
-    displayName: 'Folder';
-    pluralName: 'folders';
     singularName: 'folder';
+    pluralName: 'folders';
+    displayName: 'Folder';
   };
   pluginOptions: {
     'content-manager': {
@@ -1746,23 +442,6 @@ export interface PluginUploadFolder extends Schema.CollectionType {
     };
   };
   attributes: {
-    children: Attribute.Relation<
-      'plugin::upload.folder',
-      'oneToMany',
-      'plugin::upload.folder'
-    >;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'plugin::upload.folder',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    files: Attribute.Relation<
-      'plugin::upload.folder',
-      'oneToMany',
-      'plugin::upload.file'
-    >;
     name: Attribute.String &
       Attribute.Required &
       Attribute.SetMinMax<
@@ -1771,10 +450,21 @@ export interface PluginUploadFolder extends Schema.CollectionType {
         },
         number
       >;
+    pathId: Attribute.Integer & Attribute.Required & Attribute.Unique;
     parent: Attribute.Relation<
       'plugin::upload.folder',
       'manyToOne',
       'plugin::upload.folder'
+    >;
+    children: Attribute.Relation<
+      'plugin::upload.folder',
+      'oneToMany',
+      'plugin::upload.folder'
+    >;
+    files: Attribute.Relation<
+      'plugin::upload.folder',
+      'oneToMany',
+      'plugin::upload.file'
     >;
     path: Attribute.String &
       Attribute.Required &
@@ -1784,10 +474,203 @@ export interface PluginUploadFolder extends Schema.CollectionType {
         },
         number
       >;
-    pathId: Attribute.Integer & Attribute.Required & Attribute.Unique;
+    createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::upload.folder',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
     updatedBy: Attribute.Relation<
       'plugin::upload.folder',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface PluginContentReleasesRelease extends Schema.CollectionType {
+  collectionName: 'strapi_releases';
+  info: {
+    singularName: 'release';
+    pluralName: 'releases';
+    displayName: 'Release';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    releasedAt: Attribute.DateTime;
+    scheduledAt: Attribute.DateTime;
+    timezone: Attribute.String;
+    status: Attribute.Enumeration<
+      ['ready', 'blocked', 'failed', 'done', 'empty']
+    > &
+      Attribute.Required;
+    actions: Attribute.Relation<
+      'plugin::content-releases.release',
+      'oneToMany',
+      'plugin::content-releases.release-action'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::content-releases.release',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'plugin::content-releases.release',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface PluginContentReleasesReleaseAction
+  extends Schema.CollectionType {
+  collectionName: 'strapi_release_actions';
+  info: {
+    singularName: 'release-action';
+    pluralName: 'release-actions';
+    displayName: 'Release Action';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    type: Attribute.Enumeration<['publish', 'unpublish']> & Attribute.Required;
+    entry: Attribute.Relation<
+      'plugin::content-releases.release-action',
+      'morphToOne'
+    >;
+    contentType: Attribute.String & Attribute.Required;
+    locale: Attribute.String;
+    release: Attribute.Relation<
+      'plugin::content-releases.release-action',
+      'manyToOne',
+      'plugin::content-releases.release'
+    >;
+    isEntryValid: Attribute.Boolean;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::content-releases.release-action',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'plugin::content-releases.release-action',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface PluginPublisherAction extends Schema.CollectionType {
+  collectionName: 'actions';
+  info: {
+    singularName: 'action';
+    pluralName: 'actions';
+    displayName: 'actions';
+  };
+  options: {
+    draftAndPublish: false;
+    comment: '';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    executeAt: Attribute.DateTime;
+    mode: Attribute.String;
+    entityId: Attribute.Integer;
+    entitySlug: Attribute.String;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::publisher.action',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'plugin::publisher.action',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface PluginI18NLocale extends Schema.CollectionType {
+  collectionName: 'i18n_locale';
+  info: {
+    singularName: 'locale';
+    pluralName: 'locales';
+    collectionName: 'locales';
+    displayName: 'Locale';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.SetMinMax<
+        {
+          min: 1;
+          max: 50;
+        },
+        number
+      >;
+    code: Attribute.String & Attribute.Unique;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::i18n.locale',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'plugin::i18n.locale',
       'oneToOne',
       'admin::user'
     > &
@@ -1799,11 +682,11 @@ export interface PluginUsersPermissionsPermission
   extends Schema.CollectionType {
   collectionName: 'up_permissions';
   info: {
-    description: '';
-    displayName: 'Permission';
     name: 'permission';
-    pluralName: 'permissions';
+    description: '';
     singularName: 'permission';
+    pluralName: 'permissions';
+    displayName: 'Permission';
   };
   pluginOptions: {
     'content-manager': {
@@ -1815,19 +698,19 @@ export interface PluginUsersPermissionsPermission
   };
   attributes: {
     action: Attribute.String & Attribute.Required;
+    role: Attribute.Relation<
+      'plugin::users-permissions.permission',
+      'manyToOne',
+      'plugin::users-permissions.role'
+    >;
     createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
       'plugin::users-permissions.permission',
       'oneToOne',
       'admin::user'
     > &
       Attribute.Private;
-    role: Attribute.Relation<
-      'plugin::users-permissions.permission',
-      'manyToOne',
-      'plugin::users-permissions.role'
-    >;
-    updatedAt: Attribute.DateTime;
     updatedBy: Attribute.Relation<
       'plugin::users-permissions.permission',
       'oneToOne',
@@ -1840,11 +723,11 @@ export interface PluginUsersPermissionsPermission
 export interface PluginUsersPermissionsRole extends Schema.CollectionType {
   collectionName: 'up_roles';
   info: {
-    description: '';
-    displayName: 'Role';
     name: 'role';
-    pluralName: 'roles';
+    description: '';
     singularName: 'role';
+    pluralName: 'roles';
+    displayName: 'Role';
   };
   pluginOptions: {
     'content-manager': {
@@ -1855,119 +738,1285 @@ export interface PluginUsersPermissionsRole extends Schema.CollectionType {
     };
   };
   attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 3;
+      }>;
+    description: Attribute.String;
+    type: Attribute.String & Attribute.Unique;
+    permissions: Attribute.Relation<
+      'plugin::users-permissions.role',
+      'oneToMany',
+      'plugin::users-permissions.permission'
+    >;
+    users: Attribute.Relation<
+      'plugin::users-permissions.role',
+      'oneToMany',
+      'plugin::users-permissions.user'
+    >;
     createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
       'plugin::users-permissions.role',
       'oneToOne',
       'admin::user'
     > &
       Attribute.Private;
-    description: Attribute.String;
-    name: Attribute.String &
-      Attribute.Required &
-      Attribute.SetMinMaxLength<{
-        minLength: 3;
-      }>;
-    permissions: Attribute.Relation<
-      'plugin::users-permissions.role',
-      'oneToMany',
-      'plugin::users-permissions.permission'
-    >;
-    type: Attribute.String & Attribute.Unique;
-    updatedAt: Attribute.DateTime;
     updatedBy: Attribute.Relation<
       'plugin::users-permissions.role',
       'oneToOne',
       'admin::user'
     > &
       Attribute.Private;
-    users: Attribute.Relation<
-      'plugin::users-permissions.role',
-      'oneToMany',
-      'plugin::users-permissions.user'
-    >;
   };
 }
 
 export interface PluginUsersPermissionsUser extends Schema.CollectionType {
   collectionName: 'up_users';
   info: {
-    description: '';
-    displayName: 'User';
     name: 'user';
-    pluralName: 'users';
+    description: '';
     singularName: 'user';
+    pluralName: 'users';
+    displayName: 'User';
   };
   options: {
     draftAndPublish: false;
     timestamps: true;
   };
   attributes: {
-    blocked: Attribute.Boolean & Attribute.DefaultTo<false>;
-    confirmationToken: Attribute.String & Attribute.Private;
-    confirmed: Attribute.Boolean & Attribute.DefaultTo<false>;
-    createdAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'plugin::users-permissions.user',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    email: Attribute.Email &
-      Attribute.Required &
-      Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
-    password: Attribute.Password &
-      Attribute.Private &
-      Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
-    provider: Attribute.String;
-    resetPasswordToken: Attribute.String & Attribute.Private;
-    role: Attribute.Relation<
-      'plugin::users-permissions.user',
-      'manyToOne',
-      'plugin::users-permissions.role'
-    >;
-    updatedAt: Attribute.DateTime;
-    updatedBy: Attribute.Relation<
-      'plugin::users-permissions.user',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
     username: Attribute.String &
       Attribute.Required &
       Attribute.Unique &
       Attribute.SetMinMaxLength<{
         minLength: 3;
       }>;
+    email: Attribute.Email &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    provider: Attribute.String;
+    password: Attribute.Password &
+      Attribute.Private &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    resetPasswordToken: Attribute.String & Attribute.Private;
+    confirmationToken: Attribute.String & Attribute.Private;
+    confirmed: Attribute.Boolean & Attribute.DefaultTo<false>;
+    blocked: Attribute.Boolean & Attribute.DefaultTo<false>;
+    role: Attribute.Relation<
+      'plugin::users-permissions.user',
+      'manyToOne',
+      'plugin::users-permissions.role'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::users-permissions.user',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'plugin::users-permissions.user',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiApiToolApiTool extends Schema.CollectionType {
+  collectionName: 'api_tools';
+  info: {
+    singularName: 'api-tool';
+    pluralName: 'api-tools';
+    displayName: 'API Tool';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    tool_page_desc: Attribute.RichText;
+    new_tool: Attribute.Boolean;
+    pro_tool: Attribute.Boolean;
+    api_tool_bucket: Attribute.Relation<
+      'api::api-tool.api-tool',
+      'manyToOne',
+      'api::api-tool-bucket.api-tool-bucket'
+    >;
+    header_blurb: Attribute.String;
+    tool_card_desc: Attribute.Text;
+    icon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    youtube_url: Attribute.String;
+    parameters: Attribute.DynamicZone<['tool.parameter']>;
+    api_tool_endpoints: Attribute.Relation<
+      'api::api-tool.api-tool',
+      'oneToMany',
+      'api::api-tool-endpoint.api-tool-endpoint'
+    >;
+    why_cards: Attribute.DynamicZone<['tool.card']>;
+    why_section_title: Attribute.String;
+    why_section_desc: Attribute.Text;
+    slug: Attribute.UID<'api::api-tool.api-tool', 'name'>;
+    seo: Attribute.Component<'shared.seo'>;
+    faq: Attribute.DynamicZone<['shared.faq']>;
+    publish_date: Attribute.DateTime &
+      Attribute.DefaultTo<'2024-08-29T05:00:00.000Z'>;
+    rank: Attribute.Integer;
+    cloud_only: Attribute.Boolean;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::api-tool.api-tool',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::api-tool.api-tool',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiApiToolBucketApiToolBucket extends Schema.CollectionType {
+  collectionName: 'api_tool_buckets';
+  info: {
+    singularName: 'api-tool-bucket';
+    pluralName: 'api-tool-buckets';
+    displayName: 'API Tool Bucket';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    description: Attribute.Text;
+    api_tools: Attribute.Relation<
+      'api::api-tool-bucket.api-tool-bucket',
+      'oneToMany',
+      'api::api-tool.api-tool'
+    >;
+    rank: Attribute.Integer;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::api-tool-bucket.api-tool-bucket',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::api-tool-bucket.api-tool-bucket',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiApiToolEndpointApiToolEndpoint
+  extends Schema.CollectionType {
+  collectionName: 'api_tool_endpoints';
+  info: {
+    singularName: 'api-tool-endpoint';
+    pluralName: 'api-tool-endpoints';
+    displayName: 'API Tool Endpoint';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    endpoint: Attribute.String;
+    api_lab_json: Attribute.JSON;
+    api_tool: Attribute.Relation<
+      'api::api-tool-endpoint.api-tool-endpoint',
+      'manyToOne',
+      'api::api-tool.api-tool'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::api-tool-endpoint.api-tool-endpoint',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::api-tool-endpoint.api-tool-endpoint',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiBlogBlog extends Schema.SingleType {
+  collectionName: 'blogs';
+  info: {
+    singularName: 'blog';
+    pluralName: 'blogs';
+    displayName: ' Blog';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    seo: Attribute.Component<'shared.seo'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::blog.blog', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::blog.blog', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface ApiBlogPostBlogPost extends Schema.CollectionType {
+  collectionName: 'blog_posts';
+  info: {
+    singularName: 'blog-post';
+    pluralName: 'blog-posts';
+    displayName: 'Blog Post';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 80;
+      }>;
+    slug: Attribute.UID<'api::blog-post.blog-post', 'title'>;
+    cover: Attribute.Media<'images' | 'files' | 'videos'>;
+    publish_date: Attribute.DateTime &
+      Attribute.DefaultTo<'2024-05-14T05:00:01.148Z'>;
+    blog_post_topics: Attribute.Relation<
+      'api::blog-post.blog-post',
+      'manyToMany',
+      'api::blog-post-topic.blog-post-topic'
+    >;
+    blog_post_type: Attribute.Relation<
+      'api::blog-post.blog-post',
+      'manyToOne',
+      'api::blog-post-type.blog-post-type'
+    >;
+    blocks: Attribute.DynamicZone<['shared.rich-text', 'shared.html']>;
+    seo: Attribute.Component<'shared.seo'>;
+    short_title: Attribute.String;
+    icon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::blog-post.blog-post',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::blog-post.blog-post',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiBlogPostTopicBlogPostTopic extends Schema.CollectionType {
+  collectionName: 'blog_post_topics';
+  info: {
+    singularName: 'blog-post-topic';
+    pluralName: 'blog-post-topics';
+    displayName: 'Blog Post Topic';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    slug: Attribute.UID<'api::blog-post-topic.blog-post-topic', 'name'> &
+      Attribute.Required;
+    description: Attribute.Text;
+    blog_posts: Attribute.Relation<
+      'api::blog-post-topic.blog-post-topic',
+      'manyToMany',
+      'api::blog-post.blog-post'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::blog-post-topic.blog-post-topic',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::blog-post-topic.blog-post-topic',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiBlogPostTypeBlogPostType extends Schema.CollectionType {
+  collectionName: 'blog_post_types';
+  info: {
+    singularName: 'blog-post-type';
+    pluralName: 'blog-post-types';
+    displayName: 'Blog Post Type';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    slug: Attribute.UID<'api::blog-post-type.blog-post-type', 'name'>;
+    description: Attribute.Text;
+    blog_posts: Attribute.Relation<
+      'api::blog-post-type.blog-post-type',
+      'oneToMany',
+      'api::blog-post.blog-post'
+    >;
+    rank: Attribute.Integer;
+    name_plural: Attribute.String;
+    slug_plural: Attribute.UID<
+      'api::blog-post-type.blog-post-type',
+      'name_plural'
+    >;
+    seo: Attribute.Component<'shared.seo'>;
+    icon: Attribute.String;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::blog-post-type.blog-post-type',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::blog-post-type.blog-post-type',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiChatFeedbackModalChatFeedbackModal
+  extends Schema.SingleType {
+  collectionName: 'chat_feedback_modals';
+  info: {
+    singularName: 'chat-feedback-modal';
+    pluralName: 'chat-feedback-modals';
+    displayName: 'Chat Feedback Modal';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    input_placeholder: Attribute.String;
+    prompts: Attribute.Component<'shared.string', true>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::chat-feedback-modal.chat-feedback-modal',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::chat-feedback-modal.chat-feedback-modal',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiDocumentationDocumentation extends Schema.SingleType {
+  collectionName: 'documentations';
+  info: {
+    singularName: 'documentation';
+    pluralName: 'documentations';
+    displayName: 'Documentation';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    seo: Attribute.Component<'shared.seo'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::documentation.documentation',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::documentation.documentation',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiDocumentationSectionDocumentationSection
+  extends Schema.CollectionType {
+  collectionName: 'documentation_sections';
+  info: {
+    singularName: 'documentation-section';
+    pluralName: 'documentation-sections';
+    displayName: 'Documentation Section';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    content: Attribute.RichText & Attribute.Required;
+    title: Attribute.String & Attribute.Required;
+    description: Attribute.Text;
+    creation_date: Attribute.Date;
+    documentation_subsections: Attribute.Relation<
+      'api::documentation-section.documentation-section',
+      'oneToMany',
+      'api::documentation-section.documentation-section'
+    >;
+    slug: Attribute.UID<
+      'api::documentation-section.documentation-section',
+      'title'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::documentation-section.documentation-section',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::documentation-section.documentation-section',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiDocumentationTopicDocumentationTopic
+  extends Schema.CollectionType {
+  collectionName: 'documentation_topics';
+  info: {
+    singularName: 'documentation-topic';
+    pluralName: 'documentation-topics';
+    displayName: 'Documentation Topic';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    content: Attribute.RichText;
+    creation_date: Attribute.Date;
+    title: Attribute.String & Attribute.Required;
+    description: Attribute.Text;
+    slug: Attribute.UID<
+      'api::documentation-topic.documentation-topic',
+      'title'
+    > &
+      Attribute.Required;
+    documentation_sections: Attribute.Relation<
+      'api::documentation-topic.documentation-topic',
+      'oneToMany',
+      'api::documentation-section.documentation-section'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::documentation-topic.documentation-topic',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::documentation-topic.documentation-topic',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiGlobalGlobal extends Schema.SingleType {
+  collectionName: 'globals';
+  info: {
+    singularName: 'global';
+    pluralName: 'globals';
+    displayName: 'Global';
+    description: 'Define global settings';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    siteName: Attribute.String & Attribute.Required;
+    favicon: Attribute.Media<'images' | 'files' | 'videos'>;
+    siteDescription: Attribute.Text & Attribute.Required;
+    defaultSeo: Attribute.Component<'shared.seo'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::global.global',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::global.global',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfassistantHtmlPagePdfassistantHtmlPage
+  extends Schema.CollectionType {
+  collectionName: 'pdfassistant_html_pages';
+  info: {
+    singularName: 'pdfassistant-html-page';
+    pluralName: 'pdfassistant-html-pages';
+    displayName: 'Pdfassistant HTML Page';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    slug: Attribute.String;
+    page_type: Attribute.Enumeration<
+      ['features', 'use-cases', 'integrations', 'mcp-servers', 'plugins', 'api']
+    >;
+    html_head: Attribute.Component<'shared.html'>;
+    html_body: Attribute.Component<'shared.html'>;
+    structured_data: Attribute.JSON;
+    seo: Attribute.Component<'shared.seo'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfassistant-html-page.pdfassistant-html-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfassistant-html-page.pdfassistant-html-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfassistantPluginsOverviewPdfassistantPluginsOverview
+  extends Schema.SingleType {
+  collectionName: 'pdfassistant_plugins_overviews';
+  info: {
+    singularName: 'pdfassistant-plugins-overview';
+    pluralName: 'pdfassistant-plugins-overviews';
+    displayName: 'Pdfassistant Plugins Overview';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    content: Attribute.DynamicZone<
+      ['shared.content-section', 'product.plugins-group']
+    >;
+    seo: Attribute.Component<'shared.seo'>;
+    hero: Attribute.Component<'shared.content-section'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfassistant-plugins-overview.pdfassistant-plugins-overview',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfassistant-plugins-overview.pdfassistant-plugins-overview',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfassistantPricingPdfassistantPricing
+  extends Schema.SingleType {
+  collectionName: 'pdfassistant_pricings';
+  info: {
+    singularName: 'pdfassistant-pricing';
+    pluralName: 'pdfassistant-pricings';
+    displayName: 'Pdfassistant Pricing';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    faq: Attribute.DynamicZone<['shared.faq']>;
+    credit_plans: Attribute.DynamicZone<['pricing.card']>;
+    seo: Attribute.Component<'shared.seo', true>;
+    plan_details_table: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfassistant-pricing.pdfassistant-pricing',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfassistant-pricing.pdfassistant-pricing',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfassistantProductPdfassistantProduct
+  extends Schema.CollectionType {
+  collectionName: 'pdfassistant_products';
+  info: {
+    singularName: 'pdfassistant-product';
+    pluralName: 'pdfassistant-products';
+    displayName: 'Pdfassistant Product';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    icon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    seo: Attribute.Component<'shared.seo'>;
+    content: Attribute.DynamicZone<['shared.content-section']>;
+    slug: Attribute.UID<
+      'api::pdfassistant-product.pdfassistant-product',
+      'title'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfassistant-product.pdfassistant-product',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfassistant-product.pdfassistant-product',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestApiToolkitPdfrestApiToolkit
+  extends Schema.SingleType {
+  collectionName: 'pdfrest_api_toolkits';
+  info: {
+    singularName: 'pdfrest-api-toolkit';
+    pluralName: 'pdfrest-api-toolkits';
+    displayName: 'Pdfrest API Toolkit';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    heroContent: Attribute.Component<'api-toolkit.hero'>;
+    securityComplianceContent: Attribute.Component<'api-toolkit.security-compliance-content'>;
+    midPageCtaContent: Attribute.Component<'api-toolkit.cta'>;
+    deploymentContent: Attribute.Component<'api-toolkit.deployment-content'>;
+    deploymentCards: Attribute.Component<'api-toolkit.deployment-card', true>;
+    securityBadgeTitle: Attribute.String;
+    trustedByTitle: Attribute.String;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-api-toolkit.pdfrest-api-toolkit',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-api-toolkit.pdfrest-api-toolkit',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestContainerLicenseKeyRequestPdfrestContainerLicenseKeyRequest
+  extends Schema.SingleType {
+  collectionName: 'pdfrest_container_license_key_requests';
+  info: {
+    singularName: 'pdfrest-container-license-key-request';
+    pluralName: 'pdfrest-container-license-key-requests';
+    displayName: 'Pdfrest Container License Key Request';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    seo: Attribute.Component<'shared.seo'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-container-license-key-request.pdfrest-container-license-key-request',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-container-license-key-request.pdfrest-container-license-key-request',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestDataProcessingAgreementPdfrestDataProcessingAgreement
+  extends Schema.SingleType {
+  collectionName: 'pdfrest_data_processing_agreements';
+  info: {
+    singularName: 'pdfrest-data-processing-agreement';
+    pluralName: 'pdfrest-data-processing-agreements';
+    displayName: 'Pdfrest Data Processing Agreement';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    body: Attribute.RichText;
+    seo: Attribute.Component<'shared.seo'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-data-processing-agreement.pdfrest-data-processing-agreement',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-data-processing-agreement.pdfrest-data-processing-agreement',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestDocumentationPagePdfrestDocumentationPage
+  extends Schema.CollectionType {
+  collectionName: 'pdfrest_documentation_pages';
+  info: {
+    singularName: 'pdfrest-documentation-page';
+    pluralName: 'pdfrest-documentation-pages';
+    displayName: 'Pdfrest Documentation Page';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    slug: Attribute.UID<
+      'api::pdfrest-documentation-page.pdfrest-documentation-page',
+      'title'
+    >;
+    content: Attribute.DynamicZone<
+      [
+        'documentation.doc-section',
+        'shared.rich-text',
+        'shared.html',
+        'shared.card'
+      ]
+    >;
+    seo: Attribute.Component<'shared.seo'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-documentation-page.pdfrest-documentation-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-documentation-page.pdfrest-documentation-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestGlobalPdfrestGlobal extends Schema.SingleType {
+  collectionName: 'pdfrest_globals';
+  info: {
+    singularName: 'pdfrest-global';
+    pluralName: 'pdfrest-globals';
+    displayName: 'PdfRest Global';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    nav: Attribute.DynamicZone<['header.link']>;
+    seo: Attribute.Component<'shared.seo'>;
+    api_tool_buckets: Attribute.Relation<
+      'api::pdfrest-global.pdfrest-global',
+      'oneToMany',
+      'api::api-tool-bucket.api-tool-bucket'
+    >;
+    footer_developers: Attribute.DynamicZone<['header.link']>;
+    footer_products: Attribute.DynamicZone<['header.link']>;
+    stateful_cta: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-global.pdfrest-global',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-global.pdfrest-global',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestPricingPdfrestPricing extends Schema.SingleType {
+  collectionName: 'pdfrest_pricings';
+  info: {
+    singularName: 'pdfrest-pricing';
+    pluralName: 'pdfrest-pricings';
+    displayName: 'Pdfrest Pricing';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.RichText;
+    features_table: Attribute.JSON;
+    seo: Attribute.Component<'shared.seo'>;
+    title_cloud: Attribute.String;
+    description_cloud: Attribute.RichText;
+    pdfrest_pricing_card_group: Attribute.Relation<
+      'api::pdfrest-pricing.pdfrest-pricing',
+      'oneToOne',
+      'api::pdfrest-pricing-card.pdfrest-pricing-card'
+    >;
+    pdfrest_pricing_sections: Attribute.Relation<
+      'api::pdfrest-pricing.pdfrest-pricing',
+      'oneToMany',
+      'api::pdfrest-pricing-section.pdfrest-pricing-section'
+    >;
+    image_cloud: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    features_table_title: Attribute.String;
+    dynamic_cta: Attribute.Component<'pricing-section.dynamic-cta', true>;
+    faq_sections: Attribute.Component<'faq.faq-section', true>;
+    cloud_faq_link: Attribute.Component<'pricing-section.pricing-link'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-pricing.pdfrest-pricing',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-pricing.pdfrest-pricing',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestPricingCardPdfrestPricingCard
+  extends Schema.CollectionType {
+  collectionName: 'pdfrest_pricing_cards';
+  info: {
+    singularName: 'pdfrest-pricing-card';
+    pluralName: 'pdfrest-pricing-cards';
+    displayName: 'Pdfrest Pricing Card Group';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    card: Attribute.Component<'pricing.card', true>;
+    title: Attribute.String & Attribute.Required & Attribute.Private;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-pricing-card.pdfrest-pricing-card',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-pricing-card.pdfrest-pricing-card',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestPricingSectionPdfrestPricingSection
+  extends Schema.CollectionType {
+  collectionName: 'pdfrest_pricing_sections';
+  info: {
+    singularName: 'pdfrest-pricing-section';
+    pluralName: 'pdfrest-pricing-sections';
+    displayName: 'Pdfrest Pricing Section';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    section_header: Attribute.Component<'pricing-section.pricing-section'>;
+    features: Attribute.Component<'pricing-section.pricing-features'>;
+    cta_link: Attribute.Component<'pricing-section.pricing-link'>;
+    pdfrest_pricing_card_group: Attribute.Relation<
+      'api::pdfrest-pricing-section.pdfrest-pricing-section',
+      'oneToOne',
+      'api::pdfrest-pricing-card.pdfrest-pricing-card'
+    >;
+    pricing_card_title: Attribute.String;
+    pricing_card_description: Attribute.Text;
+    Title: Attribute.String & Attribute.Required & Attribute.Private;
+    cta_title: Attribute.String;
+    ctas: Attribute.Component<'pricing-section.cta', true>;
+    faq_link: Attribute.Component<'pricing-section.pricing-link'>;
+    features_table: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-pricing-section.pdfrest-pricing-section',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-pricing-section.pdfrest-pricing-section',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestPrivacyPolicyPdfrestPrivacyPolicy
+  extends Schema.SingleType {
+  collectionName: 'pdfrest_privacy_policies';
+  info: {
+    singularName: 'pdfrest-privacy-policy';
+    pluralName: 'pdfrest-privacy-policies';
+    displayName: 'Pdfrest Privacy Policy';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    body: Attribute.RichText;
+    seo: Attribute.Component<'shared.seo'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-privacy-policy.pdfrest-privacy-policy',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-privacy-policy.pdfrest-privacy-policy',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestProductPdfrestProduct extends Schema.CollectionType {
+  collectionName: 'pdfrest_products';
+  info: {
+    singularName: 'pdfrest-product';
+    pluralName: 'pdfrest-products';
+    displayName: 'Pdfrest Product';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    cta: Attribute.Component<'shared.cta'>;
+    overview_cards: Attribute.Component<'shared.card', true>;
+    overview_sections: Attribute.Component<'shared.card', true>;
+    tools_section_title: Attribute.String;
+    tools_section_description: Attribute.RichText;
+    tool_groups: Attribute.Component<'product.tool-group', true>;
+    pricing_section_title: Attribute.String;
+    pricing_section_description: Attribute.RichText;
+    pricing_links: Attribute.Component<'header.link', true>;
+    docs_section_title: Attribute.String;
+    docs_section_description: Attribute.RichText;
+    docs_links: Attribute.Component<'header.link', true>;
+    icon: Attribute.String;
+    slug: Attribute.UID<'api::pdfrest-product.pdfrest-product', 'title'>;
+    seo: Attribute.Component<'shared.seo'>;
+    final_cta: Attribute.Component<'shared.cta'>;
+    deployment: Attribute.Component<'shared.content-section'>;
+    pro_tools_title: Attribute.String;
+    pro_tools_description: Attribute.RichText;
+    pdfrest_pricing_card_group: Attribute.Relation<
+      'api::pdfrest-product.pdfrest-product',
+      'oneToOne',
+      'api::pdfrest-pricing-card.pdfrest-pricing-card'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-product.pdfrest-product',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-product.pdfrest-product',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestSecurityPdfrestSecurity extends Schema.SingleType {
+  collectionName: 'pdfrest_securities';
+  info: {
+    singularName: 'pdfrest-security';
+    pluralName: 'pdfrest-securities';
+    displayName: 'Pdfrest Security';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    seo: Attribute.Component<'shared.seo'>;
+    content: Attribute.Component<'product.pdfassistant-product-section', true>;
+    cta: Attribute.Component<'shared.cta'>;
+    hero: Attribute.Component<'product.pdfassistant-product-section'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-security.pdfrest-security',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-security.pdfrest-security',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestSecurityCertificationPdfrestSecurityCertification
+  extends Schema.SingleType {
+  collectionName: 'pdfrest_security_certifications';
+  info: {
+    singularName: 'pdfrest-security-certification';
+    pluralName: 'pdfrest-security-certifications';
+    displayName: 'Pdfrest Security Certification';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    certification_icons: Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios',
+      true
+    >;
+    links: Attribute.Component<'pricing-section.pricing-link', true>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-security-certification.pdfrest-security-certification',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-security-certification.pdfrest-security-certification',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPdfrestTermsOfServicePdfrestTermsOfService
+  extends Schema.SingleType {
+  collectionName: 'pdfrest_terms_of_services';
+  info: {
+    singularName: 'pdfrest-terms-of-service';
+    pluralName: 'pdfrest-terms-of-services';
+    displayName: 'Pdfrest Terms of Service';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String;
+    description: Attribute.Text;
+    body: Attribute.RichText;
+    seo: Attribute.Component<'shared.seo'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pdfrest-terms-of-service.pdfrest-terms-of-service',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pdfrest-terms-of-service.pdfrest-terms-of-service',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
   };
 }
 
 declare module '@strapi/types' {
   export module Shared {
     export interface ContentTypes {
+      'admin::permission': AdminPermission;
+      'admin::user': AdminUser;
+      'admin::role': AdminRole;
       'admin::api-token': AdminApiToken;
       'admin::api-token-permission': AdminApiTokenPermission;
-      'admin::permission': AdminPermission;
-      'admin::role': AdminRole;
       'admin::transfer-token': AdminTransferToken;
       'admin::transfer-token-permission': AdminTransferTokenPermission;
-      'admin::user': AdminUser;
+      'plugin::upload.file': PluginUploadFile;
+      'plugin::upload.folder': PluginUploadFolder;
+      'plugin::content-releases.release': PluginContentReleasesRelease;
+      'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;
+      'plugin::publisher.action': PluginPublisherAction;
+      'plugin::i18n.locale': PluginI18NLocale;
+      'plugin::users-permissions.permission': PluginUsersPermissionsPermission;
+      'plugin::users-permissions.role': PluginUsersPermissionsRole;
+      'plugin::users-permissions.user': PluginUsersPermissionsUser;
+      'api::api-tool.api-tool': ApiApiToolApiTool;
       'api::api-tool-bucket.api-tool-bucket': ApiApiToolBucketApiToolBucket;
       'api::api-tool-endpoint.api-tool-endpoint': ApiApiToolEndpointApiToolEndpoint;
-      'api::api-tool.api-tool': ApiApiToolApiTool;
+      'api::blog.blog': ApiBlogBlog;
+      'api::blog-post.blog-post': ApiBlogPostBlogPost;
       'api::blog-post-topic.blog-post-topic': ApiBlogPostTopicBlogPostTopic;
       'api::blog-post-type.blog-post-type': ApiBlogPostTypeBlogPostType;
-      'api::blog-post.blog-post': ApiBlogPostBlogPost;
-      'api::blog.blog': ApiBlogBlog;
       'api::chat-feedback-modal.chat-feedback-modal': ApiChatFeedbackModalChatFeedbackModal;
+      'api::documentation.documentation': ApiDocumentationDocumentation;
       'api::documentation-section.documentation-section': ApiDocumentationSectionDocumentationSection;
       'api::documentation-topic.documentation-topic': ApiDocumentationTopicDocumentationTopic;
-      'api::documentation.documentation': ApiDocumentationDocumentation;
       'api::global.global': ApiGlobalGlobal;
+      'api::pdfassistant-html-page.pdfassistant-html-page': ApiPdfassistantHtmlPagePdfassistantHtmlPage;
       'api::pdfassistant-plugins-overview.pdfassistant-plugins-overview': ApiPdfassistantPluginsOverviewPdfassistantPluginsOverview;
       'api::pdfassistant-pricing.pdfassistant-pricing': ApiPdfassistantPricingPdfassistantPricing;
       'api::pdfassistant-product.pdfassistant-product': ApiPdfassistantProductPdfassistantProduct;
@@ -1976,23 +2025,14 @@ declare module '@strapi/types' {
       'api::pdfrest-data-processing-agreement.pdfrest-data-processing-agreement': ApiPdfrestDataProcessingAgreementPdfrestDataProcessingAgreement;
       'api::pdfrest-documentation-page.pdfrest-documentation-page': ApiPdfrestDocumentationPagePdfrestDocumentationPage;
       'api::pdfrest-global.pdfrest-global': ApiPdfrestGlobalPdfrestGlobal;
+      'api::pdfrest-pricing.pdfrest-pricing': ApiPdfrestPricingPdfrestPricing;
       'api::pdfrest-pricing-card.pdfrest-pricing-card': ApiPdfrestPricingCardPdfrestPricingCard;
       'api::pdfrest-pricing-section.pdfrest-pricing-section': ApiPdfrestPricingSectionPdfrestPricingSection;
-      'api::pdfrest-pricing.pdfrest-pricing': ApiPdfrestPricingPdfrestPricing;
       'api::pdfrest-privacy-policy.pdfrest-privacy-policy': ApiPdfrestPrivacyPolicyPdfrestPrivacyPolicy;
       'api::pdfrest-product.pdfrest-product': ApiPdfrestProductPdfrestProduct;
-      'api::pdfrest-security-certification.pdfrest-security-certification': ApiPdfrestSecurityCertificationPdfrestSecurityCertification;
       'api::pdfrest-security.pdfrest-security': ApiPdfrestSecurityPdfrestSecurity;
+      'api::pdfrest-security-certification.pdfrest-security-certification': ApiPdfrestSecurityCertificationPdfrestSecurityCertification;
       'api::pdfrest-terms-of-service.pdfrest-terms-of-service': ApiPdfrestTermsOfServicePdfrestTermsOfService;
-      'plugin::content-releases.release': PluginContentReleasesRelease;
-      'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;
-      'plugin::i18n.locale': PluginI18NLocale;
-      'plugin::publisher.action': PluginPublisherAction;
-      'plugin::upload.file': PluginUploadFile;
-      'plugin::upload.folder': PluginUploadFolder;
-      'plugin::users-permissions.permission': PluginUsersPermissionsPermission;
-      'plugin::users-permissions.role': PluginUsersPermissionsRole;
-      'plugin::users-permissions.user': PluginUsersPermissionsUser;
     }
   }
 }


### PR DESCRIPTION
PDFCLOUD-5902

## Why this change
Add a new Strapi content type for managing Pdfassistant HTML pages in a structured way, with guidance for generating content consistently.

## What changed
- Introduces the `pdfassistant-html-page` content type and its controller, service, and routes
- Adds two authoring guides for AI and marketing use cases
- Updates generated Strapi types and package metadata to support the new setup
- Includes a patch for the import/export module so exports can target specific content types instead of relying on full JSON exports only

## Notes
The import/export patch was added to fix the issue described in the commit and to address full JSON export failures in production. The new behavior keeps exports usable by limiting them to selected types when needed, rather than depending on complete JSON exports.