### PR TITLE
Add public description field to HTML pages

### DIFF
--- a/docs/pdfassistant-html-page-ai-guide.md
+++ b/docs/pdfassistant-html-page-ai-guide.md
@@ -9,6 +9,7 @@ Your output must match the field structure exactly and must avoid full-document 
 Generate content for these fields:
 
 - `title`
+- `description`
 - `slug`
 - `page_type`
 - `html_head`
@@ -20,11 +21,19 @@ Generate content for these fields:
 
 ### `title`
 
-- Purpose: internal tracking and search inside Strapi
-- Output: short human-readable page name
+- Purpose: public header link title shown to users
+- Output: short human-readable page name for the header link
 - Examples:
   - `MCP Servers Overview`
   - `Claude`
+
+### `description`
+
+- Purpose: public header link description shown to users
+- Output: short descriptive summary for the page link
+- Examples:
+  - `Explore MCP servers that connect AI tools to PDF workflows.`
+  - `Connect Claude to pdfassistant for AI-powered PDF automation.`
 
 ### `slug`
 
@@ -146,6 +155,9 @@ Example:
 title
 Claude
 
+description
+Connect Claude to pdfassistant for AI-powered PDF workflows.
+
 slug
 claude
 
@@ -181,7 +193,8 @@ Learn how Claude works with pdfassistant for AI-powered PDF workflows.
 
 Before returning content, confirm:
 
-- `title` is useful for internal search
+- `title` works as the public header link title
+- `description` works as the public header link description
 - `slug` is blank only for overview pages
 - `slug` uses kebab-case when present
 - `page_type` is valid

--- a/docs/pdfassistant-html-page-marketing-guide.md
+++ b/docs/pdfassistant-html-page-marketing-guide.md
@@ -27,13 +27,13 @@ You do **not** need to build a full website page. Only provide the pieces reques
 ### `title`
 
 What it is:
-An internal name for finding the entry later in Strapi.
+The public title shown on the header link for this page.
 
 How to fill it in:
 
 - Use a clear, human-readable title.
-- Write something you can search for easily later.
 - Match the topic of the page.
+- Write it the way you want users to see it in the header link.
 
 Good examples:
 
@@ -43,8 +43,29 @@ Good examples:
 
 Best practice:
 
-- Treat this as an internal label, not the URL.
+- Treat this as the public link title, not the URL.
 - Keep it descriptive and specific.
+
+### `description`
+
+What it is:
+The public description shown on the header link for this page.
+
+How to fill it in:
+
+- Write a short summary of what the page is about.
+- Make it useful to a reader scanning the header links.
+- Keep it specific to the page topic.
+
+Good examples:
+
+- `Explore MCP servers that connect AI tools to PDF workflows.`
+- `Connect Claude to pdfassistant for AI-powered PDF automation.`
+
+Best practice:
+
+- Treat this as supporting copy for the title.
+- Keep it concise, clear, and user-facing.
 
 ### `slug`
 
@@ -253,7 +274,8 @@ Example:
 
 Before publishing, confirm:
 
-- `title` is clear and searchable.
+- `title` is clear as the public header link title.
+- `description` is clear as the public header link description.
 - `slug` is filled in for detail pages and blank for overview pages.
 - `page_type` matches the page category.
 - `html_head` contains only head-related code.
@@ -276,12 +298,14 @@ Before publishing, confirm:
 ## Example: Overview Page
 
 - `title`: `MCP Servers Overview`
+- `description`: `Explore MCP servers that connect AI tools to PDF workflows.`
 - `slug`: leave blank
 - `page_type`: `mcp-servers`
 
 ## Example: Detail Page
 
 - `title`: `Claude`
+- `description`: `Connect Claude to pdfassistant for AI-powered PDF workflows.`
 - `slug`: `claude`
 - `page_type`: `integrations`
 
@@ -289,7 +313,8 @@ Before publishing, confirm:
 
 If you are unsure what belongs in a field, use this shortcut:
 
-- Search/organization name: `title`
+- Public header link title: `title`
+- Public header link description: `description`
 - URL piece: `slug`
 - Section/category: `page_type`
 - Styles and head links: `html_head`

--- a/src/api/pdfassistant-html-page/content-types/pdfassistant-html-page/schema.json
+++ b/src/api/pdfassistant-html-page/content-types/pdfassistant-html-page/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "pdfassistant-html-page",
     "pluralName": "pdfassistant-html-pages",
-    "displayName": "Pdfassistant HTML Page"
+    "displayName": "Pdfassistant HTML Page",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -16,6 +17,9 @@
     },
     "slug": {
       "type": "string"
+    },
+    "description": {
+      "type": "text"
     },
     "page_type": {
       "type": "enumeration",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1398,6 +1398,7 @@ export interface ApiPdfassistantHtmlPagePdfassistantHtmlPage
     singularName: 'pdfassistant-html-page';
     pluralName: 'pdfassistant-html-pages';
     displayName: 'Pdfassistant HTML Page';
+    description: '';
   };
   options: {
     draftAndPublish: true;
@@ -1405,6 +1406,7 @@ export interface ApiPdfassistantHtmlPagePdfassistantHtmlPage
   attributes: {
     title: Attribute.String;
     slug: Attribute.String;
+    description: Attribute.Text;
     page_type: Attribute.Enumeration<
       ['features', 'use-cases', 'integrations', 'mcp-servers', 'plugins', 'api']
     >;


### PR DESCRIPTION
## Why this change
HTML page entries needed a user-facing description alongside the title so header links can show clearer context.

## What changed
- Added a new `description` field to the `pdfassistant-html-page` content type.
- Updated the AI and marketing authoring guides to describe the new field.
- Regenerated the TypeScript content type definitions so they match the schema.

## Behavior changes
- Page records can now store and expose a short public description.
- Existing pages without a description are unchanged.

## Validation
- Verified the schema, docs, and generated types were updated together.

## Risks and follow-ups
- Content creators and automation that produce these entries should start populating `description` where a richer header link summary is useful.
